### PR TITLE
Add unit tests for admin pages

### DIFF
--- a/client/src/pages/admin/AdminDashboard.js
+++ b/client/src/pages/admin/AdminDashboard.js
@@ -13,9 +13,13 @@ const AdminDashboard = () => {
           </div>
           <div className="col-md-9">
             <div className="card w-75 p-3">
-              <h3> Admin Name : {auth?.user?.name}</h3>
-              <h3> Admin Email : {auth?.user?.email}</h3>
-              <h3> Admin Contact : {auth?.user?.phone}</h3>
+              <h3 data-testid="admin-name">Admin Name : {auth?.user?.name}</h3>
+              <h3 data-testid="admin-email">
+                Admin Email : {auth?.user?.email}
+              </h3>
+              <h3 data-testid="admin-contact">
+                Admin Contact : {auth?.user?.phone}
+              </h3>
             </div>
           </div>
         </div>

--- a/client/src/pages/admin/AdminDashboard.test.js
+++ b/client/src/pages/admin/AdminDashboard.test.js
@@ -1,0 +1,53 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+
+import AdminDashboard from "./AdminDashboard";
+import { useAuth } from "../../context/auth";
+
+// Mock dependencies
+jest.mock("../../components/Layout", () => ({ children }) => (
+  <div data-testid="layout">{children}</div>
+));
+
+jest.mock("../../components/AdminMenu", () => () => (
+  <div data-testid="admin-menu">Mock AdminMenu</div>
+));
+
+jest.mock("../../context/auth", () => ({
+  useAuth: jest.fn(),
+}));
+
+describe("AdminDashboard Component", () => {
+  it("should display admin details when authenticated", () => {
+    const mockAuthData = {
+      user: {
+        name: "Admin User",
+        email: "admin@example.com",
+        phone: "1234567890",
+      },
+      token: "valid-token",
+    };
+    useAuth.mockReturnValue([mockAuthData]);
+
+    render(<AdminDashboard />);
+
+    // Expect the AdminMenu component to be rendered with the correct props
+    expect(screen.getByText("Admin Name : Admin User")).toBeInTheDocument();
+    expect(
+      screen.getByText("Admin Email : admin@example.com")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Admin Contact : 1234567890")).toBeInTheDocument();
+  });
+
+  it("should not crash when user is not authenticated", () => {
+    useAuth.mockReturnValue([{ user: null, token: null }]);
+
+    render(<AdminDashboard />);
+
+    // Expect the AdminMenu component to be rendered with empty props
+    expect(screen.getByText("Admin Name :")).toBeInTheDocument();
+    expect(screen.getByText("Admin Email :")).toBeInTheDocument();
+    expect(screen.getByText("Admin Contact :")).toBeInTheDocument();
+  });
+});

--- a/client/src/pages/admin/AdminDashboard.test.js
+++ b/client/src/pages/admin/AdminDashboard.test.js
@@ -33,11 +33,11 @@ describe("AdminDashboard Component", () => {
     render(<AdminDashboard />);
 
     // Expect the AdminMenu component to be rendered with the correct props
-    expect(screen.getByText("Admin Name : Admin User")).toBeInTheDocument();
-    expect(
-      screen.getByText("Admin Email : admin@example.com")
-    ).toBeInTheDocument();
-    expect(screen.getByText("Admin Contact : 1234567890")).toBeInTheDocument();
+    expect(screen.getByTestId("admin-name")).toHaveTextContent("Admin User");
+    expect(screen.getByTestId("admin-email")).toHaveTextContent(
+      "admin@example.com"
+    );
+    expect(screen.getByTestId("admin-contact")).toHaveTextContent("1234567890");
   });
 
   it("should not crash when user is not authenticated", () => {
@@ -46,8 +46,12 @@ describe("AdminDashboard Component", () => {
     render(<AdminDashboard />);
 
     // Expect the AdminMenu component to be rendered with empty props
-    expect(screen.getByText("Admin Name :")).toBeInTheDocument();
-    expect(screen.getByText("Admin Email :")).toBeInTheDocument();
-    expect(screen.getByText("Admin Contact :")).toBeInTheDocument();
+    expect(screen.getByTestId("admin-name")).toHaveTextContent("Admin Name :");
+    expect(screen.getByTestId("admin-email")).toHaveTextContent(
+      "Admin Email :"
+    );
+    expect(screen.getByTestId("admin-contact")).toHaveTextContent(
+      "Admin Contact :"
+    );
   });
 });

--- a/client/src/pages/admin/AdminOrders.js
+++ b/client/src/pages/admin/AdminOrders.js
@@ -8,22 +8,24 @@ import moment from "moment";
 import { Select } from "antd";
 const { Option } = Select;
 
+const status = [
+  "Not Processed",
+  "Processing",
+  "Shipped",
+  "Delivered",
+  "Cancelled",
+];
+
 const AdminOrders = () => {
-  const [status, setStatus] = useState([
-    "Not Process",
-    "Processing",
-    "Shipped",
-    "deliverd",
-    "cancel",
-  ]);
-  const [changeStatus, setCHangeStatus] = useState("");
   const [orders, setOrders] = useState([]);
-  const [auth, setAuth] = useAuth();
+  const [auth] = useAuth();
+
   const getOrders = async () => {
     try {
       const { data } = await axios.get("/api/v1/auth/all-orders");
       setOrders(data);
     } catch (error) {
+      toast.error("Something went wrong while fetching orders");
       console.log(error);
     }
   };
@@ -34,11 +36,12 @@ const AdminOrders = () => {
 
   const handleChange = async (orderId, value) => {
     try {
-      const { data } = await axios.put(`/api/v1/auth/order-status/${orderId}`, {
+      await axios.put(`/api/v1/auth/order-status/${orderId}`, {
         status: value,
       });
       getOrders();
     } catch (error) {
+      toast.error("Something went wrong while updating status");
       console.log(error);
     }
   };
@@ -48,18 +51,22 @@ const AdminOrders = () => {
         <div className="col-md-3">
           <AdminMenu />
         </div>
-        <div className="col-md-9">
+        <div className="col-md-9" data-testid="admin-orders-list">
           <h1 className="text-center">All Orders</h1>
           {orders?.map((o, i) => {
             return (
-              <div className="border shadow" key={o._id}>
+              <div
+                className="border shadow"
+                key={o._id}
+                data-testid={`admin-order-item-${i}`}
+              >
                 <table className="table">
                   <thead>
                     <tr>
                       <th scope="col">#</th>
                       <th scope="col">Status</th>
                       <th scope="col">Buyer</th>
-                      <th scope="col"> date</th>
+                      <th scope="col">Date</th>
                       <th scope="col">Payment</th>
                       <th scope="col">Quantity</th>
                     </tr>

--- a/client/src/pages/admin/AdminOrders.js
+++ b/client/src/pages/admin/AdminOrders.js
@@ -8,6 +8,17 @@ import moment from "moment";
 import { Select } from "antd";
 const { Option } = Select;
 
+export const ADMIN_ORDERS_STRINGS = {
+  FETCH_ORDERS_ERROR: "Something went wrong while fetching orders",
+  UPDATE_STATUS_ERROR: "Something went wrong while updating status",
+};
+
+export const API_URLS = {
+  GET_ALL_ORDERS: "/api/v1/auth/all-orders",
+  UPDATE_ORDER_STATUS: "/api/v1/auth/order-status",
+  GET_PRODUCT_PHOTO: "/api/v1/product/product-photo",
+};
+
 const status = [
   "Not Processed",
   "Processing",
@@ -22,10 +33,10 @@ const AdminOrders = () => {
 
   const getOrders = async () => {
     try {
-      const { data } = await axios.get("/api/v1/auth/all-orders");
+      const { data } = await axios.get(API_URLS.GET_ALL_ORDERS);
       setOrders(data);
     } catch (error) {
-      toast.error("Something went wrong while fetching orders");
+      toast.error(ADMIN_ORDERS_STRINGS.FETCH_ORDERS_ERROR);
       console.log(error);
     }
   };
@@ -36,12 +47,12 @@ const AdminOrders = () => {
 
   const handleChange = async (orderId, value) => {
     try {
-      await axios.put(`/api/v1/auth/order-status/${orderId}`, {
+      await axios.put(`${API_URLS.UPDATE_ORDER_STATUS}/${orderId}`, {
         status: value,
       });
       getOrders();
     } catch (error) {
-      toast.error("Something went wrong while updating status");
+      toast.error(ADMIN_ORDERS_STRINGS.UPDATE_STATUS_ERROR);
       console.log(error);
     }
   };
@@ -100,7 +111,7 @@ const AdminOrders = () => {
                     <div className="row mb-2 p-3 card flex-row" key={p._id}>
                       <div className="col-md-4">
                         <img
-                          src={`/api/v1/product/product-photo/${p._id}`}
+                          src={`${API_URLS.GET_PRODUCT_PHOTO}/${p._id}`}
                           className="card-img-top"
                           alt={p.name}
                           width="100px"

--- a/client/src/pages/admin/AdminOrders.js
+++ b/client/src/pages/admin/AdminOrders.js
@@ -52,7 +52,7 @@ const AdminOrders = () => {
           <h1 className="text-center">All Orders</h1>
           {orders?.map((o, i) => {
             return (
-              <div className="border shadow">
+              <div className="border shadow" key={o._id}>
                 <table className="table">
                   <thead>
                     <tr>
@@ -69,12 +69,13 @@ const AdminOrders = () => {
                       <td>{i + 1}</td>
                       <td>
                         <Select
-                          bordered={false}
+                          data-testid={`status-${o._id}`}
+                          variant="borderless"
                           onChange={(value) => handleChange(o._id, value)}
                           defaultValue={o?.status}
                         >
                           {status.map((s, i) => (
-                            <Option key={i} value={s}>
+                            <Option key={s} value={s}>
                               {s}
                             </Option>
                           ))}

--- a/client/src/pages/admin/AdminOrders.test.js
+++ b/client/src/pages/admin/AdminOrders.test.js
@@ -1,7 +1,12 @@
 import React from "react";
 import toast from "react-hot-toast";
-import { render, screen, waitFor, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
 import axios from "axios";
 
@@ -17,7 +22,7 @@ jest.mock("react-hot-toast", () => ({
 }));
 
 jest.mock("antd", () => {
-  const actualAntd = jest.requireActual("antd"); // Keep other Antd components working
+  const actualAntd = jest.requireActual("antd");
   const MockSelect = ({
     children,
     onChange,
@@ -190,7 +195,7 @@ describe("AdminOrders Component", () => {
 
     const newShippingStatus = "Shipped";
     const select = screen.getByTestId(`status-${mockOrders[0]._id}`);
-    userEvent.selectOptions(select, newShippingStatus);
+    fireEvent.change(select, { target: { value: newShippingStatus } });
 
     await waitFor(() =>
       expect(axios.put).toHaveBeenCalledWith(
@@ -218,7 +223,7 @@ describe("AdminOrders Component", () => {
 
     const newShippingStatus = "Shipped";
     const select = screen.getByTestId(`status-${mockOrders[0]._id}`);
-    userEvent.selectOptions(select, newShippingStatus);
+    fireEvent.change(select, { target: { value: newShippingStatus } });
 
     await waitFor(() =>
       expect(axios.put).toHaveBeenCalledWith(

--- a/client/src/pages/admin/AdminOrders.test.js
+++ b/client/src/pages/admin/AdminOrders.test.js
@@ -1,0 +1,148 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import axios from "axios";
+
+import AdminOrders from "./AdminOrders";
+import { useAuth } from "../../context/auth";
+
+// Mock dependencies
+jest.mock("axios");
+
+jest.mock("../../components/Layout", () => ({ children }) => (
+  <div data-testid="layout">{children}</div>
+));
+
+jest.mock("../../components/AdminMenu", () => () => (
+  <div data-testid="admin-menu">Mock AdminMenu</div>
+));
+
+jest.mock("../../context/auth", () => ({
+  useAuth: jest.fn(),
+}));
+
+describe("AdminOrders Component", () => {
+  let consoleLogSpy;
+  const mockAuthData = {
+    user: { name: "Admin User" },
+    token: "valid-token",
+  };
+  const mockOrders = [
+    {
+      _id: "1",
+      status: "Processing",
+      buyer: { name: "John Doe" },
+      createAt: new Date().toISOString(),
+      payment: { success: true },
+      products: [
+        {
+          _id: "p1",
+          name: "Product 1",
+          description: "Product Description 1",
+          price: 100,
+        },
+      ],
+    },
+    {
+      _id: "2",
+      status: "Not Process",
+      buyer: { name: "Jane Doe" },
+      createAt: new Date().toISOString(),
+      payment: { success: false },
+      products: [
+        {
+          _id: "p2",
+          name: "Product 2",
+          description: "Product Description 2",
+          price: 200,
+        },
+      ],
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  it("should display orders when authenticated", async () => {
+    useAuth.mockReturnValue([mockAuthData]);
+    axios.get.mockResolvedValueOnce({ data: mockOrders });
+
+    render(<AdminOrders />);
+
+    await screen.findByText("All Orders");
+    expect(axios.get).toHaveBeenCalled();
+    await screen.findByText("John Doe");
+    expect(screen.getByText("Processing")).toBeInTheDocument();
+    expect(screen.getByText("Product 1")).toBeInTheDocument();
+    expect(screen.getByText("Product Description 1")).toBeInTheDocument();
+  });
+
+  // TODO Fix this test
+  //   it("should handle order status change", async () => {
+  //     useAuth.mockReturnValue([mockAuthData]);
+  //     const copyMockOrders = [...mockOrders];
+  //     copyMockOrders[0].status = "Shipped";
+
+  //     axios.get.mockResolvedValueOnce({ data: mockOrders });
+  //     //   .mockResolvedValueOnce({ data: copyMockOrders });
+  //     axios.put.mockResolvedValueOnce({ data: { success: true } });
+
+  //     render(<AdminOrders />);
+
+  //     await screen.findByText("All Orders");
+  //     await screen.findByText("John Doe");
+
+  //     const select = screen.getByTestId(`status-${mockOrders[0]._id}`);
+  //     console.info(select.value, select);
+
+  //     const selectElement = screen.getByRole("combobox");
+  //     userEvent.click(selectElement);
+
+  //     console.info(select.value);
+  //     expect(axios.put).toHaveBeenCalled();
+
+  //     // fireEvent.change(select, { target: { value: "Shipped" } });
+  //     // await waitFor(() => expect(axios.put).toHaveBeenCalled());
+  //   });
+
+  it("should display no orders message when there are no orders", async () => {
+    useAuth.mockReturnValue([mockAuthData]);
+    axios.get.mockResolvedValueOnce({ data: [] });
+
+    render(<AdminOrders />);
+
+    await screen.findByText("All Orders");
+    expect(axios.get).toHaveBeenCalled();
+  });
+
+  it("should not fetch orders when not authenticated", async () => {
+    useAuth.mockReturnValue([
+      {
+        user: null,
+        token: "",
+      },
+    ]);
+    render(<AdminOrders />);
+
+    await screen.findByText("All Orders");
+    expect(axios.get).not.toHaveBeenCalled();
+  });
+
+  it("should display error message on failed get orders", async () => {
+    useAuth.mockReturnValue([mockAuthData]);
+    const mockError = new Error("Failed to fetch orders");
+    axios.get.mockRejectedValue(mockError);
+
+    render(<AdminOrders />);
+
+    await screen.findByText("All Orders");
+    expect(axios.get).toHaveBeenCalled();
+    expect(consoleLogSpy).toHaveBeenCalledWith(mockError);
+  });
+});

--- a/client/src/pages/admin/CreateCategory.js
+++ b/client/src/pages/admin/CreateCategory.js
@@ -5,13 +5,29 @@ import toast from "react-hot-toast";
 import axios from "axios";
 import CategoryForm from "../../components/Form/CategoryForm";
 import { Modal } from "antd";
+
+export const CREATE_CATEGORY_STRINGS = {
+  CREATE_CATEGORY_ACTION: "Create Category",
+  UPDATE_CATEGORY_ACTION: "Edit",
+  DELETE_CATEGORY_ACTION: "Delete",
+
+  CREATE_CATEGORY_ERROR: "Something went wrong in creating category",
+  FETCH_CATEGORY_ERROR: "Something went wrong in getting category",
+  UPDATE_CATEGORY_ERROR: "Something went wrong in updating category",
+  DELETE_CATEGORY_ERROR: "Something went wrong in deleting category",
+
+  CATEGORY_CREATED: "Category created successfully",
+  CATEGORY_UPDATED: "Category updated successfully",
+  CATEGORY_DELETED: "Category deleted successfully",
+};
+
 const CreateCategory = () => {
   const [categories, setCategories] = useState([]);
   const [name, setName] = useState("");
   const [visible, setVisible] = useState(false);
   const [selected, setSelected] = useState(null);
   const [updatedName, setUpdatedName] = useState("");
-  //handle Form
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
@@ -19,27 +35,28 @@ const CreateCategory = () => {
         name,
       });
       if (data?.success) {
-        toast.success(`${name} is created`);
-        getAllCategory();
+        toast.success(CREATE_CATEGORY_STRINGS.CATEGORY_CREATED);
       } else {
-        toast.error(data.message);
+        throw new Error("Error in creating category");
       }
     } catch (error) {
+      toast.error(CREATE_CATEGORY_STRINGS.CREATE_CATEGORY_ERROR);
       console.log(error);
-      toast.error("somthing went wrong in input form");
     }
+    getAllCategory();
   };
 
-  //get all cat
   const getAllCategory = async () => {
     try {
       const { data } = await axios.get("/api/v1/category/get-category");
       if (data.success) {
         setCategories(data.category);
+      } else {
+        throw new Error("Error in getting category");
       }
     } catch (error) {
+      toast.error(CREATE_CATEGORY_STRINGS.FETCH_CATEGORY_ERROR);
       console.log(error);
-      toast.error("Something wwent wrong in getting catgeory");
     }
   };
 
@@ -47,7 +64,6 @@ const CreateCategory = () => {
     getAllCategory();
   }, []);
 
-  //update category
   const handleUpdate = async (e) => {
     e.preventDefault();
     try {
@@ -56,35 +72,35 @@ const CreateCategory = () => {
         { name: updatedName }
       );
       if (data.success) {
-        toast.success(`${updatedName} is updated`);
+        toast.success(CREATE_CATEGORY_STRINGS.CATEGORY_UPDATED);
         setSelected(null);
         setUpdatedName("");
         setVisible(false);
-        getAllCategory();
       } else {
-        toast.error(data.message);
+        throw new Error("Error in updating category");
       }
     } catch (error) {
-      toast.error("Somtihing went wrong");
+      toast.error(CREATE_CATEGORY_STRINGS.UPDATE_CATEGORY_ERROR);
     }
+    getAllCategory();
   };
-  //delete category
+
   const handleDelete = async (pId) => {
     try {
       const { data } = await axios.delete(
         `/api/v1/category/delete-category/${pId}`
       );
       if (data.success) {
-        toast.success(`category is deleted`);
-
-        getAllCategory();
+        toast.success(CREATE_CATEGORY_STRINGS.CATEGORY_DELETED);
       } else {
-        toast.error(data.message);
+        throw new Error("Error in deleting category");
       }
     } catch (error) {
-      toast.error("Somtihing went wrong");
+      toast.error(CREATE_CATEGORY_STRINGS.DELETE_CATEGORY_ERROR);
     }
+    getAllCategory();
   };
+
   return (
     <Layout title={"Dashboard - Create Category"}>
       <div className="container-fluid m-3 p-3">
@@ -109,33 +125,33 @@ const CreateCategory = () => {
                     <th scope="col">Actions</th>
                   </tr>
                 </thead>
-                <tbody>
+                <tbody data-testid="create-category-list">
                   {categories?.map((c) => (
-                    <>
-                      <tr>
-                        <td key={c._id}>{c.name}</td>
-                        <td>
-                          <button
-                            className="btn btn-primary ms-2"
-                            onClick={() => {
-                              setVisible(true);
-                              setUpdatedName(c.name);
-                              setSelected(c);
-                            }}
-                          >
-                            Edit
-                          </button>
-                          <button
-                            className="btn btn-danger ms-2"
-                            onClick={() => {
-                              handleDelete(c._id);
-                            }}
-                          >
-                            Delete
-                          </button>
-                        </td>
-                      </tr>
-                    </>
+                    <tr key={c._id} data-testid={`create-category-${c._id}`}>
+                      <td>{c.name}</td>
+                      <td>
+                        <button
+                          className="btn btn-primary ms-2"
+                          data-testid={`update-category-${c._id}`}
+                          onClick={() => {
+                            setVisible(true);
+                            setUpdatedName(c.name);
+                            setSelected(c);
+                          }}
+                        >
+                          {CREATE_CATEGORY_STRINGS.UPDATE_CATEGORY_ACTION}
+                        </button>
+                        <button
+                          className="btn btn-danger ms-2"
+                          data-testid={`delete-category-${c._id}`}
+                          onClick={() => {
+                            handleDelete(c._id);
+                          }}
+                        >
+                          {CREATE_CATEGORY_STRINGS.DELETE_CATEGORY_ACTION}
+                        </button>
+                      </td>
+                    </tr>
                   ))}
                 </tbody>
               </table>
@@ -143,13 +159,15 @@ const CreateCategory = () => {
             <Modal
               onCancel={() => setVisible(false)}
               footer={null}
-              visible={visible}
+              open={visible}
             >
-              <CategoryForm
-                value={updatedName}
-                setValue={setUpdatedName}
-                handleSubmit={handleUpdate}
-              />
+              <div data-testid="update-category-modal">
+                <CategoryForm
+                  value={updatedName}
+                  setValue={setUpdatedName}
+                  handleSubmit={handleUpdate}
+                />
+              </div>
             </Modal>
           </div>
         </div>

--- a/client/src/pages/admin/CreateCategory.test.js
+++ b/client/src/pages/admin/CreateCategory.test.js
@@ -1,0 +1,414 @@
+import React from "react";
+import toast from "react-hot-toast";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import axios from "axios";
+
+import CreateCategory, { CREATE_CATEGORY_STRINGS } from "./CreateCategory";
+
+// Mock dependencies
+jest.mock("axios");
+
+jest.mock("react-hot-toast", () => ({
+  error: jest.fn(),
+  success: jest.fn(),
+}));
+
+jest.mock("../../components/Layout", () => ({ children }) => (
+  <div data-testid="layout">{children}</div>
+));
+
+jest.mock("../../components/AdminMenu", () => () => (
+  <div data-testid="admin-menu">Mock AdminMenu</div>
+));
+
+jest.mock(
+  "../../components/Form/CategoryForm",
+  () =>
+    ({ handleSubmit, value, setValue }) =>
+      (
+        <div data-testid="category-form">
+          <input
+            data-testid="category-input"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+          />
+          <button data-testid="submit-button" onClick={handleSubmit}>
+            Submit
+          </button>
+        </div>
+      )
+);
+
+describe("CreateCategory Component", () => {
+  const mockCategories = [{ _id: "1", name: "Electronics" }];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should fetch and display categories", async () => {
+    axios.get.mockResolvedValueOnce({
+      data: { success: true, category: mockCategories },
+    });
+
+    render(<CreateCategory />);
+
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId("create-category-list")).queryAllByTestId(
+          /create-category-/
+        )
+      ).toHaveLength(mockCategories.length)
+    );
+    expect(axios.get).toHaveBeenCalled();
+  });
+
+  it("should display error when fetching categories fails", async () => {
+    axios.get.mockResolvedValueOnce({ data: { success: false } });
+    render(<CreateCategory />);
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        CREATE_CATEGORY_STRINGS.FETCH_CATEGORY_ERROR
+      )
+    );
+    expect(
+      within(screen.getByTestId("create-category-list")).queryAllByTestId(
+        /create-category-/
+      )
+    ).toHaveLength(0);
+  });
+
+  it("should display error when fetching categories throws exception", async () => {
+    axios.get.mockRejectedValueOnce(new Error("Fetch failed"));
+    render(<CreateCategory />);
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        CREATE_CATEGORY_STRINGS.FETCH_CATEGORY_ERROR
+      )
+    );
+    expect(
+      within(screen.getByTestId("create-category-list")).queryAllByTestId(
+        /create-category-/
+      )
+    ).toHaveLength(0);
+  });
+
+  it("should create a new category and display success message", async () => {
+    axios.post.mockResolvedValueOnce({ data: { success: true } });
+    axios.get.mockResolvedValueOnce({
+      data: { success: true, category: mockCategories },
+    });
+
+    render(<CreateCategory />);
+
+    // Wait for categories to be displayed
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId("create-category-list")).queryAllByTestId(
+          /create-category-/
+        )
+      ).toHaveLength(mockCategories.length)
+    );
+
+    // Create a new category
+    const input = screen.getByTestId("category-input");
+    fireEvent.change(input, { target: { value: "New Category" } });
+    fireEvent.click(screen.getByTestId("submit-button"));
+
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith(
+        CREATE_CATEGORY_STRINGS.CATEGORY_CREATED
+      )
+    );
+    expect(axios.post).toHaveBeenCalledWith(
+      "/api/v1/category/create-category",
+      { name: "New Category" }
+    );
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("should display error when category creation fails", async () => {
+    axios.post.mockResolvedValueOnce({ data: { success: false } });
+    axios.get.mockResolvedValueOnce({
+      data: { success: true, category: mockCategories },
+    });
+
+    render(<CreateCategory />);
+
+    // Wait for categories to be displayed
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId("create-category-list")).queryAllByTestId(
+          /create-category-/
+        )
+      ).toHaveLength(mockCategories.length)
+    );
+
+    fireEvent.click(screen.getByTestId("submit-button"));
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        CREATE_CATEGORY_STRINGS.CREATE_CATEGORY_ERROR
+      )
+    );
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("should display error when category creation throws exception", async () => {
+    axios.post.mockRejectedValueOnce(new Error("Creation failed"));
+    axios.get.mockResolvedValueOnce({
+      data: { success: true, category: mockCategories },
+    });
+
+    render(<CreateCategory />);
+
+    // Wait for categories to be displayed
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId("create-category-list")).queryAllByTestId(
+          /create-category-/
+        )
+      ).toHaveLength(mockCategories.length)
+    );
+
+    fireEvent.click(screen.getByTestId("submit-button"));
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        CREATE_CATEGORY_STRINGS.CREATE_CATEGORY_ERROR
+      )
+    );
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("should delete a category and display success message", async () => {
+    axios.delete.mockResolvedValueOnce({ data: { success: true } });
+    axios.get.mockResolvedValueOnce({
+      data: { success: true, category: mockCategories },
+    });
+
+    render(<CreateCategory />);
+
+    // Wait for categories to be displayed
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId("create-category-list")).queryAllByTestId(
+          /create-category-/
+        )
+      ).toHaveLength(mockCategories.length)
+    );
+
+    const id = mockCategories[0]._id;
+    fireEvent.click(screen.getByTestId(`delete-category-${id}`));
+
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith(
+        CREATE_CATEGORY_STRINGS.CATEGORY_DELETED
+      )
+    );
+    expect(axios.delete).toHaveBeenCalledWith(
+      `/api/v1/category/delete-category/${id}`
+    );
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("should display error when category deletion fails", async () => {
+    axios.delete.mockResolvedValueOnce({ data: { success: false } });
+    axios.get.mockResolvedValueOnce({
+      data: { success: true, category: mockCategories },
+    });
+
+    render(<CreateCategory />);
+
+    // Wait for categories to be displayed
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId("create-category-list")).queryAllByTestId(
+          /create-category-/
+        )
+      ).toHaveLength(mockCategories.length)
+    );
+
+    const id = mockCategories[0]._id;
+    fireEvent.click(screen.getByTestId(`delete-category-${id}`));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        CREATE_CATEGORY_STRINGS.DELETE_CATEGORY_ERROR
+      )
+    );
+    expect(axios.delete).toHaveBeenCalledWith(
+      `/api/v1/category/delete-category/${id}`
+    );
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("should display error when category deletion throws exception", async () => {
+    axios.delete.mockRejectedValueOnce(new Error("Deletion failed"));
+    axios.get.mockResolvedValueOnce({
+      data: { success: true, category: mockCategories },
+    });
+
+    render(<CreateCategory />);
+
+    // Wait for categories to be displayed
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId("create-category-list")).queryAllByTestId(
+          /create-category-/
+        )
+      ).toHaveLength(mockCategories.length)
+    );
+
+    const id = mockCategories[0]._id;
+    fireEvent.click(screen.getByTestId(`delete-category-${id}`));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        CREATE_CATEGORY_STRINGS.DELETE_CATEGORY_ERROR
+      )
+    );
+    expect(axios.delete).toHaveBeenCalledWith(
+      `/api/v1/category/delete-category/${id}`
+    );
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("should update a category and display success message", async () => {
+    axios.put.mockResolvedValueOnce({ data: { success: true } });
+    axios.get.mockResolvedValueOnce({
+      data: { success: true, category: mockCategories },
+    });
+
+    render(<CreateCategory />);
+
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId("create-category-list")).queryAllByTestId(
+          /create-category-/
+        )
+      ).toHaveLength(mockCategories.length)
+    );
+
+    const id = mockCategories[0]._id;
+    fireEvent.click(screen.getByTestId(`update-category-${id}`));
+    const modal = screen.getByTestId("update-category-modal");
+    fireEvent.change(within(modal).getByTestId("category-input"), {
+      target: { value: "Updated Category" },
+    });
+    fireEvent.click(within(modal).getByTestId("submit-button"));
+
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith(
+        CREATE_CATEGORY_STRINGS.CATEGORY_UPDATED
+      )
+    );
+    expect(axios.put).toHaveBeenCalledWith(
+      `/api/v1/category/update-category/${id}`,
+      { name: "Updated Category" }
+    );
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("should display error when category update fails", async () => {
+    axios.put.mockResolvedValueOnce({ data: { success: false } });
+    axios.get.mockResolvedValueOnce({
+      data: { success: true, category: mockCategories },
+    });
+
+    render(<CreateCategory />);
+
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId("create-category-list")).queryAllByTestId(
+          /create-category-/
+        )
+      ).toHaveLength(mockCategories.length)
+    );
+
+    const id = mockCategories[0]._id;
+    fireEvent.click(screen.getByTestId(`update-category-${id}`));
+    const modal = screen.getByTestId("update-category-modal");
+    fireEvent.change(within(modal).getByTestId("category-input"), {
+      target: { value: "Updated Category" },
+    });
+    fireEvent.click(within(modal).getByTestId("submit-button"));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        CREATE_CATEGORY_STRINGS.UPDATE_CATEGORY_ERROR
+      )
+    );
+    expect(axios.put).toHaveBeenCalledWith(
+      `/api/v1/category/update-category/${id}`,
+      { name: "Updated Category" }
+    );
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("should display error when category update throws exception", async () => {
+    axios.put.mockRejectedValueOnce(new Error("Update failed"));
+    axios.get.mockResolvedValueOnce({
+      data: { success: true, category: mockCategories },
+    });
+
+    render(<CreateCategory />);
+
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId("create-category-list")).queryAllByTestId(
+          /create-category-/
+        )
+      ).toHaveLength(mockCategories.length)
+    );
+
+    const id = mockCategories[0]._id;
+    fireEvent.click(screen.getByTestId(`update-category-${id}`));
+    const modal = screen.getByTestId("update-category-modal");
+    fireEvent.change(within(modal).getByTestId("category-input"), {
+      target: { value: "Updated Category" },
+    });
+    fireEvent.click(within(modal).getByTestId("submit-button"));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        CREATE_CATEGORY_STRINGS.UPDATE_CATEGORY_ERROR
+      )
+    );
+    expect(axios.put).toHaveBeenCalledWith(
+      `/api/v1/category/update-category/${id}`,
+      { name: "Updated Category" }
+    );
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("should cancel modal", async () => {
+    axios.get.mockResolvedValueOnce({
+      data: { success: true, category: mockCategories },
+    });
+
+    render(<CreateCategory />);
+
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId("create-category-list")).queryAllByTestId(
+          /create-category-/
+        )
+      ).toHaveLength(mockCategories.length)
+    );
+
+    const id = mockCategories[0]._id;
+    fireEvent.click(screen.getByTestId(`update-category-${id}`));
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(axios.put).not.toHaveBeenCalled();
+    expect(axios.get).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/pages/admin/Products.js
+++ b/client/src/pages/admin/Products.js
@@ -4,24 +4,28 @@ import Layout from "./../../components/Layout";
 import axios from "axios";
 import toast from "react-hot-toast";
 import { Link } from "react-router-dom";
+
+export const PRODUCTS_STRINGS = {
+  FETCH_PRODUCTS_ERROR: "Someething went wrong while fetching products",
+};
+
 const Products = () => {
   const [products, setProducts] = useState([]);
 
-  //getall products
-  const getAllProducts = async () => {
-    try {
-      const { data } = await axios.get("/api/v1/product/get-product");
-      setProducts(data.products);
-    } catch (error) {
-      console.log(error);
-      toast.error("Someething Went Wrong");
-    }
-  };
-
-  //lifecycle method
   useEffect(() => {
+    const getAllProducts = async () => {
+      try {
+        const { data } = await axios.get("/api/v1/product/get-product");
+        setProducts(data.products);
+      } catch (error) {
+        toast.error(PRODUCTS_STRINGS.FETCH_PRODUCTS_ERROR);
+        console.log(error);
+      }
+    };
+
     getAllProducts();
   }, []);
+
   return (
     <Layout>
       <div className="row">
@@ -30,14 +34,18 @@ const Products = () => {
         </div>
         <div className="col-md-9 ">
           <h1 className="text-center">All Products List</h1>
-          <div className="d-flex">
-            {products?.map((p) => (
+          <div className="d-flex" data-testid="admin-products-list">
+            {products?.map((p, index) => (
               <Link
                 key={p._id}
                 to={`/dashboard/admin/product/${p.slug}`}
                 className="product-link"
               >
-                <div className="card m-2" style={{ width: "18rem" }}>
+                <div
+                  className="card m-2"
+                  style={{ width: "18rem" }}
+                  data-testid={`admin-product-${index}`}
+                >
                   <img
                     src={`/api/v1/product/product-photo/${p._id}`}
                     className="card-img-top"

--- a/client/src/pages/admin/Products.test.js
+++ b/client/src/pages/admin/Products.test.js
@@ -1,10 +1,10 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import toast from "react-hot-toast";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
 import axios from "axios";
-import toast from "react-hot-toast";
 
-import Products from "./Products";
+import Products, { PRODUCTS_STRINGS } from "./Products";
 
 // Mock dependencies
 jest.mock("axios");
@@ -48,14 +48,17 @@ describe("Products Component", () => {
 
   it("should display products when API call is successful", async () => {
     axios.get.mockResolvedValueOnce({ data: { products: mockProducts } });
+
     render(<Products />);
 
-    await screen.findByText("All Products List");
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId("admin-products-list")).queryAllByTestId(
+          /admin-product-/
+        )
+      ).toHaveLength(mockProducts.length)
+    );
     expect(axios.get).toHaveBeenCalled();
-    await screen.findByText("Product 1");
-    expect(screen.getByText("Description of product 1")).toBeInTheDocument();
-    expect(screen.getByText("Product 2")).toBeInTheDocument();
-    expect(screen.getByText("Description of product 2")).toBeInTheDocument();
   });
 
   it("should display no products when API returns an empty array", async () => {
@@ -63,7 +66,13 @@ describe("Products Component", () => {
 
     render(<Products />);
 
-    await screen.findByText("All Products List");
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId("admin-products-list")).queryAllByTestId(
+          /admin-product-/
+        )
+      ).toHaveLength(0)
+    );
     expect(axios.get).toHaveBeenCalled();
   });
 
@@ -73,8 +82,16 @@ describe("Products Component", () => {
 
     render(<Products />);
 
-    await screen.findByText("All Products List");
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId("admin-products-list")).queryAllByTestId(
+          /admin-product-/
+        )
+      ).toHaveLength(0)
+    );
     expect(axios.get).toHaveBeenCalled();
-    expect(toast.error).toHaveBeenCalledWith("Someething Went Wrong");
+    expect(toast.error).toHaveBeenCalledWith(
+      PRODUCTS_STRINGS.FETCH_PRODUCTS_ERROR
+    );
   });
 });

--- a/client/src/pages/admin/Products.test.js
+++ b/client/src/pages/admin/Products.test.js
@@ -1,0 +1,80 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import axios from "axios";
+import toast from "react-hot-toast";
+
+import Products from "./Products";
+
+// Mock dependencies
+jest.mock("axios");
+
+jest.mock("react-router-dom", () => ({
+  Link: ({ children, to }) => <a href={to}>{children}</a>,
+}));
+
+jest.mock("react-hot-toast", () => ({
+  success: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.mock("../../components/Layout", () => ({ children }) => (
+  <div data-testid="layout">{children}</div>
+));
+
+jest.mock("../../components/AdminMenu", () => () => (
+  <div data-testid="admin-menu">Mock AdminMenu</div>
+));
+
+describe("Products Component", () => {
+  const mockProducts = [
+    {
+      _id: "1",
+      name: "Product 1",
+      description: "Description of product 1",
+      slug: "product-1",
+    },
+    {
+      _id: "2",
+      name: "Product 2",
+      description: "Description of product 2",
+      slug: "product-2",
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should display products when API call is successful", async () => {
+    axios.get.mockResolvedValueOnce({ data: { products: mockProducts } });
+    render(<Products />);
+
+    await screen.findByText("All Products List");
+    expect(axios.get).toHaveBeenCalled();
+    await screen.findByText("Product 1");
+    expect(screen.getByText("Description of product 1")).toBeInTheDocument();
+    expect(screen.getByText("Product 2")).toBeInTheDocument();
+    expect(screen.getByText("Description of product 2")).toBeInTheDocument();
+  });
+
+  it("should display no products when API returns an empty array", async () => {
+    axios.get.mockResolvedValueOnce({ data: { products: [] } });
+
+    render(<Products />);
+
+    await screen.findByText("All Products List");
+    expect(axios.get).toHaveBeenCalled();
+  });
+
+  it("should display an error message when API call fails", async () => {
+    const mockError = new Error("Failed to fetch products");
+    axios.get.mockRejectedValueOnce(mockError);
+
+    render(<Products />);
+
+    await screen.findByText("All Products List");
+    expect(axios.get).toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith("Someething Went Wrong");
+  });
+});

--- a/client/src/pages/admin/UpdateProduct.js
+++ b/client/src/pages/admin/UpdateProduct.js
@@ -7,6 +7,38 @@ import { Select } from "antd";
 import { useNavigate, useParams } from "react-router-dom";
 const { Option } = Select;
 
+export const UPDATE_PRODUCT_STRINGS = {
+  UPDATE_PRODUCT_ACTION: "UPDATE PRODUCT",
+  DELETE_PRODUCT_ACTION: "DELETE PRODUCT",
+  SELECT_CATEGORY_ACTION: "Select a category",
+  UPLOAD_PHOTO_ACTION: "Upload Photo",
+  SELECT_SHIPPING_ACTION: "Select Shipping",
+  SELECT_SHIPPING_YES_ACTION: "Yes",
+  SELECT_SHIPPING_NO_ACTION: "No",
+  DELETE_PRODUCT_CONFIRM:
+    "Delete Product? Enter any key to confirm. This action is irreversible.",
+
+  PRODUCT_NAME_PLACEHOLDER: "write a name",
+  PRODUCT_DESCRIPTION_PLACEHOLDER: "write a description",
+  PRODUCT_PRICE_PLACEHOLDER: "write a Price",
+  PRODUCT_QUANTITY_PLACEHOLDER: "write a quantity",
+
+  FETCH_PRODUCT_ERROR: "Something went wrong in getting product",
+  FETCH_CATEGORY_ERROR: "Something went wrong in getting category",
+  UPDATE_PRODUCT_ERROR: "Something went wrong in updating product",
+  DELETE_PRODUCT_ERROR: "Something went wrong in deleting product",
+
+  PRODUCT_UPDATED: "Product updated successfully",
+  PRODUCT_DELETED: "Product deleted successfully",
+};
+
+export const API_URLS = {
+  GET_PRODUCT: "/api/v1/product/get-product",
+  GET_CATEGORY: "/api/v1/category/get-category",
+  UPDATE_PRODUCT: "/api/v1/product/update-product",
+  DELETE_PRODUCT: "/api/v1/product/delete-product",
+};
+
 const UpdateProduct = () => {
   const navigate = useNavigate();
   const params = useParams();
@@ -20,46 +52,50 @@ const UpdateProduct = () => {
   const [photo, setPhoto] = useState("");
   const [id, setId] = useState("");
 
-  //get single product
-  const getSingleProduct = async () => {
-    try {
-      const { data } = await axios.get(
-        `/api/v1/product/get-product/${params.slug}`
-      );
-      setName(data.product.name);
-      setId(data.product._id);
-      setDescription(data.product.description);
-      setPrice(data.product.price);
-      setPrice(data.product.price);
-      setQuantity(data.product.quantity);
-      setShipping(data.product.shipping);
-      setCategory(data.product.category._id);
-    } catch (error) {
-      console.log(error);
-    }
-  };
+  // Fetch single product on component mount or when slug changes
   useEffect(() => {
-    getSingleProduct();
-    //eslint-disable-next-line
-  }, []);
-  //get all category
-  const getAllCategory = async () => {
-    try {
-      const { data } = await axios.get("/api/v1/category/get-category");
-      if (data?.success) {
-        setCategories(data?.category);
+    const getSingleProduct = async () => {
+      try {
+        const { data } = await axios.get(
+          `${API_URLS.GET_PRODUCT}/${params.slug}`
+        );
+        setName(data.product.name);
+        setId(data.product._id);
+        setDescription(data.product.description);
+        setPrice(data.product.price);
+        setPrice(data.product.price);
+        setQuantity(data.product.quantity);
+        setShipping(data.product.shipping);
+        setCategory(data.product.category._id);
+      } catch (error) {
+        toast.error(UPDATE_PRODUCT_STRINGS.FETCH_PRODUCT_ERROR);
+        console.log(error);
       }
-    } catch (error) {
-      console.log(error);
-      toast.error("Something wwent wrong in getting catgeory");
-    }
-  };
+    };
 
+    getSingleProduct();
+  }, [params.slug]);
+
+  // Fetch all categories on component mount
   useEffect(() => {
+    const getAllCategory = async () => {
+      try {
+        const { data } = await axios.get(API_URLS.GET_CATEGORY);
+        if (!data?.success) {
+          throw new Error("Error in getting category");
+        }
+
+        setCategories(data?.category);
+      } catch (error) {
+        console.log(error);
+        toast.error(UPDATE_PRODUCT_STRINGS.FETCH_CATEGORY_ERROR);
+      }
+    };
+
     getAllCategory();
   }, []);
 
-  //create product function
+  // Create product function
   const handleUpdate = async (e) => {
     e.preventDefault();
     try {
@@ -71,36 +107,38 @@ const UpdateProduct = () => {
       photo && productData.append("photo", photo);
       productData.append("category", category);
       const { data } = axios.put(
-        `/api/v1/product/update-product/${id}`,
+        `${API_URLS.UPDATE_PRODUCT}/${id}`,
         productData
       );
       if (data?.success) {
-        toast.success("Product Updated Successfully");
+        toast.success(UPDATE_PRODUCT_STRINGS.PRODUCT_UPDATED);
         navigate("/dashboard/admin/products");
       } else {
-        toast.error(data?.message);
+        toast.error(UPDATE_PRODUCT_STRINGS.UPDATE_PRODUCT_ERROR);
       }
     } catch (error) {
+      toast.error(UPDATE_PRODUCT_STRINGS.UPDATE_PRODUCT_ERROR);
       console.log(error);
-      toast.error("something went wrong");
     }
   };
 
-  //delete a product
+  // Delete product function
   const handleDelete = async () => {
     try {
-      let answer = window.prompt("Are You Sure want to delete this product ? ");
-      if (!answer) return;
-      const { data } = await axios.delete(
-        `/api/v1/product/delete-product/${id}`
+      const answer = window.prompt(
+        UPDATE_PRODUCT_STRINGS.DELETE_PRODUCT_CONFIRM
       );
-      toast.success("Product DEleted Succfully");
+      if (!answer) return;
+
+      await axios.delete(`${API_URLS.DELETE_PRODUCT}/${id}`);
+      toast.success(UPDATE_PRODUCT_STRINGS.PRODUCT_DELETED);
       navigate("/dashboard/admin/products");
     } catch (error) {
+      toast.error(UPDATE_PRODUCT_STRINGS.DELETE_PRODUCT_ERROR);
       console.log(error);
-      toast.error("Something went wrong");
     }
   };
+
   return (
     <Layout title={"Dashboard - Create Product"}>
       <div className="container-fluid m-3 p-3">
@@ -113,7 +151,7 @@ const UpdateProduct = () => {
             <div className="m-1 w-75">
               <Select
                 variant="borderless"
-                placeholder="Select a category"
+                placeholder={UPDATE_PRODUCT_STRINGS.SELECT_CATEGORY_ACTION}
                 size="large"
                 showSearch
                 className="form-select mb-3"
@@ -121,6 +159,7 @@ const UpdateProduct = () => {
                   setCategory(value);
                 }}
                 value={category}
+                data-testid="admin-update-product-category-select"
               >
                 {categories?.map((c) => (
                   <Option key={c._id} value={c._id}>
@@ -129,8 +168,13 @@ const UpdateProduct = () => {
                 ))}
               </Select>
               <div className="mb-3">
-                <label className="btn btn-outline-secondary col-md-12">
-                  {photo ? photo.name : "Upload Photo"}
+                <label
+                  className="btn btn-outline-secondary col-md-12"
+                  data-testid="admin-upload-photo-button"
+                >
+                  {photo
+                    ? photo.name
+                    : UPDATE_PRODUCT_STRINGS.UPLOAD_PHOTO_ACTION}
                   <input
                     type="file"
                     name="photo"
@@ -165,18 +209,22 @@ const UpdateProduct = () => {
                 <input
                   type="text"
                   value={name}
-                  placeholder="write a name"
+                  placeholder={UPDATE_PRODUCT_STRINGS.PRODUCT_NAME_PLACEHOLDER}
                   className="form-control"
                   onChange={(e) => setName(e.target.value)}
+                  data-testid="admin-update-product-name-input"
                 />
               </div>
               <div className="mb-3">
                 <textarea
                   type="text"
                   value={description}
-                  placeholder="write a description"
+                  placeholder={
+                    UPDATE_PRODUCT_STRINGS.PRODUCT_DESCRIPTION_PLACEHOLDER
+                  }
                   className="form-control"
                   onChange={(e) => setDescription(e.target.value)}
+                  data-testid="admin-update-product-description-input"
                 />
               </div>
 
@@ -184,44 +232,65 @@ const UpdateProduct = () => {
                 <input
                   type="number"
                   value={price}
-                  placeholder="write a Price"
+                  placeholder={UPDATE_PRODUCT_STRINGS.PRODUCT_PRICE_PLACEHOLDER}
                   className="form-control"
                   onChange={(e) => setPrice(e.target.value)}
+                  data-testid="admin-update-product-price-input"
                 />
               </div>
               <div className="mb-3">
                 <input
                   type="number"
                   value={quantity}
-                  placeholder="write a quantity"
+                  placeholder={
+                    UPDATE_PRODUCT_STRINGS.PRODUCT_QUANTITY_PLACEHOLDER
+                  }
                   className="form-control"
                   onChange={(e) => setQuantity(e.target.value)}
+                  data-testid="admin-update-product-quantity-input"
                 />
               </div>
               <div className="mb-3">
                 <Select
                   variant="borderless"
-                  placeholder="Select Shipping "
+                  placeholder={UPDATE_PRODUCT_STRINGS.SELECT_SHIPPING_ACTION}
                   size="large"
                   showSearch
                   className="form-select mb-3"
                   onChange={(value) => {
-                    setShipping(value);
+                    setShipping(value === "true");
                   }}
-                  value={shipping ? "yes" : "No"}
+                  value={
+                    shipping
+                      ? UPDATE_PRODUCT_STRINGS.SELECT_SHIPPING_YES_ACTION
+                      : UPDATE_PRODUCT_STRINGS.SELECT_SHIPPING_NO_ACTION
+                  }
+                  data-testid="admin-update-product-shipping-select"
                 >
-                  <Option value="0">No</Option>
-                  <Option value="1">Yes</Option>
+                  <Option value="false">
+                    {UPDATE_PRODUCT_STRINGS.SELECT_SHIPPING_NO_ACTION}
+                  </Option>
+                  <Option value="true">
+                    {UPDATE_PRODUCT_STRINGS.SELECT_SHIPPING_YES_ACTION}
+                  </Option>
                 </Select>
               </div>
               <div className="mb-3">
-                <button className="btn btn-primary" onClick={handleUpdate}>
-                  UPDATE PRODUCT
+                <button
+                  className="btn btn-primary"
+                  onClick={handleUpdate}
+                  data-testid="admin-update-product-button"
+                >
+                  {UPDATE_PRODUCT_STRINGS.UPDATE_PRODUCT_ACTION}
                 </button>
               </div>
               <div className="mb-3">
-                <button className="btn btn-danger" onClick={handleDelete}>
-                  DELETE PRODUCT
+                <button
+                  className="btn btn-danger"
+                  onClick={handleDelete}
+                  data-testid="admin-delete-product-button"
+                >
+                  {UPDATE_PRODUCT_STRINGS.DELETE_PRODUCT_ACTION}
                 </button>
               </div>
             </div>

--- a/client/src/pages/admin/UpdateProduct.js
+++ b/client/src/pages/admin/UpdateProduct.js
@@ -75,10 +75,10 @@ const UpdateProduct = () => {
         productData
       );
       if (data?.success) {
-        toast.error(data?.message);
-      } else {
         toast.success("Product Updated Successfully");
         navigate("/dashboard/admin/products");
+      } else {
+        toast.error(data?.message);
       }
     } catch (error) {
       console.log(error);
@@ -112,7 +112,7 @@ const UpdateProduct = () => {
             <h1>Update Product</h1>
             <div className="m-1 w-75">
               <Select
-                bordered={false}
+                variant="borderless"
                 placeholder="Select a category"
                 size="large"
                 showSearch
@@ -200,7 +200,7 @@ const UpdateProduct = () => {
               </div>
               <div className="mb-3">
                 <Select
-                  bordered={false}
+                  variant="borderless"
                   placeholder="Select Shipping "
                   size="large"
                   showSearch

--- a/client/src/pages/admin/UpdateProduct.test.js
+++ b/client/src/pages/admin/UpdateProduct.test.js
@@ -1,0 +1,367 @@
+import React from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import toast from "react-hot-toast";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import axios from "axios";
+
+import UpdateProduct from "./UpdateProduct";
+
+// Mock dependencies
+jest.mock("axios");
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: jest.fn(),
+  useParams: jest.fn(),
+}));
+
+jest.mock("react-hot-toast", () => ({
+  error: jest.fn(),
+  success: jest.fn(),
+}));
+
+jest.mock("../../components/Layout", () => ({ children }) => (
+  <div data-testid="layout">{children}</div>
+));
+
+jest.mock("../../components/AdminMenu", () => () => (
+  <div data-testid="admin-menu">Mock AdminMenu</div>
+));
+
+describe("UpdateProduct Component", () => {
+  const mockNavigate = jest.fn();
+  const mockParams = { slug: "test-product" };
+  const mockProduct = {
+    product: {
+      _id: "123",
+      name: "Test Product",
+      description: "Test Description",
+      price: 100,
+      quantity: 5,
+      shipping: true,
+      category: { _id: "cat1", name: "Category 1" },
+    },
+  };
+  const mockCategories = [
+    {
+      _id: "Category 1",
+      name: "Category 1",
+    },
+    {
+      _id: "Category 2",
+      name: "Category 2",
+    },
+  ];
+
+  const GET_SINGLE_PRODUCT_URL = `/api/v1/product/get-product/${mockParams.slug}`;
+  const GET_ALL_CATEGORIES_URL = "/api/v1/category/get-category";
+  let consoleLogSpy;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useNavigate.mockReturnValue(mockNavigate);
+    useParams.mockReturnValue(mockParams);
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  it("should fetch and display product details", async () => {
+    axios.get.mockImplementation((url) => {
+      if (url === GET_SINGLE_PRODUCT_URL) {
+        return Promise.resolve({ data: mockProduct });
+      }
+      if (url === GET_ALL_CATEGORIES_URL) {
+        return Promise.resolve({
+          data: { success: true, category: mockCategories },
+        });
+      }
+    });
+
+    render(<UpdateProduct />);
+
+    await screen.findByDisplayValue("Test Product");
+    expect(axios.get).toHaveBeenCalledTimes(2);
+    expect(axios.get).toHaveBeenCalledWith(GET_SINGLE_PRODUCT_URL);
+    expect(axios.get).toHaveBeenCalledWith(GET_ALL_CATEGORIES_URL);
+    expect(screen.getByDisplayValue("Test Product")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Test Description")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("100")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("5")).toBeInTheDocument();
+  });
+
+  it("should handle failure while fetching product details", async () => {
+    const mockError = new Error("Failed to fetch product");
+    axios.get.mockImplementation((url) => {
+      if (url === GET_SINGLE_PRODUCT_URL) {
+        return Promise.reject(mockError);
+      } else if (url === GET_ALL_CATEGORIES_URL) {
+        return Promise.resolve({
+          data: { success: true, category: mockCategories },
+        });
+      }
+    });
+
+    render(<UpdateProduct />);
+
+    await waitFor(() => {
+      expect(consoleLogSpy).toHaveBeenCalledWith(mockError);
+    });
+    expect(axios.get).toHaveBeenCalledTimes(2);
+    expect(axios.get).toHaveBeenCalledWith(GET_SINGLE_PRODUCT_URL);
+    expect(axios.get).toHaveBeenCalledWith(GET_ALL_CATEGORIES_URL);
+  });
+
+  it("should handle failure while fetching categories", async () => {
+    axios.get.mockImplementation((url) => {
+      if (url === GET_ALL_CATEGORIES_URL) {
+        return Promise.resolve({ data: { success: false } });
+      }
+      return Promise.resolve({ data: mockProduct });
+    });
+
+    render(<UpdateProduct />);
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledTimes(2);
+    });
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "Something wwent wrong in getting catgeory"
+    );
+  });
+
+  it("should handle exception thrown while fetching categories", async () => {
+    axios.get.mockImplementation((url) => {
+      if (url === GET_ALL_CATEGORIES_URL) {
+        return Promise.reject(new Error("Failed to fetch categories"));
+      }
+      return Promise.resolve({ data: mockProduct });
+    });
+
+    render(<UpdateProduct />);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "Something wwent wrong in getting catgeory"
+      );
+    });
+  });
+
+  it("should update the product successfully", async () => {
+    axios.get.mockImplementation((url) => {
+      if (url === GET_SINGLE_PRODUCT_URL) {
+        return Promise.resolve({ data: mockProduct });
+      } else if (url === GET_ALL_CATEGORIES_URL) {
+        return Promise.resolve({
+          data: { success: true, category: mockCategories },
+        });
+      }
+    });
+    axios.put.mockImplementation((_, __) => ({
+      data: { success: true },
+    }));
+
+    render(<UpdateProduct />);
+
+    // Update product details and submit the form
+    await screen.findByDisplayValue("Test Product");
+    fireEvent.change(screen.getByPlaceholderText("write a name"), {
+      target: { value: "Updated Product" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("write a description"), {
+      target: { value: "Updated Description" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("write a Price"), {
+      target: { value: "200" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("write a quantity"), {
+      target: { value: "10" },
+    });
+    // TODO - Add test for category change
+    fireEvent.click(screen.getByText("UPDATE PRODUCT"));
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(
+        "Product Updated Successfully"
+      );
+    });
+    expect(mockNavigate).toHaveBeenCalledWith("/dashboard/admin/products");
+  });
+
+  it("should handle failure during product update", async () => {
+    const mockErrorMessage = "Failed to update product";
+    axios.get.mockImplementation((url) => {
+      if (url === GET_SINGLE_PRODUCT_URL) {
+        return Promise.resolve({ data: mockProduct });
+      } else if (url === GET_ALL_CATEGORIES_URL) {
+        return Promise.resolve({
+          data: { success: true, category: mockCategories },
+        });
+      }
+    });
+    axios.put.mockImplementation((url, data) => ({
+      data: { success: false, message: mockErrorMessage },
+    }));
+
+    render(<UpdateProduct />);
+
+    // Trigger the update button click
+    fireEvent.click(screen.getByText("UPDATE PRODUCT"));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(mockErrorMessage);
+    });
+  });
+
+  it("should handle exception thrown during product update", async () => {
+    axios.get.mockImplementation((url) => {
+      if (url === GET_SINGLE_PRODUCT_URL) {
+        return Promise.resolve({ data: mockProduct });
+      } else if (url === GET_ALL_CATEGORIES_URL) {
+        return Promise.resolve({
+          data: { success: true, category: mockCategories },
+        });
+      }
+    });
+    axios.put.mockImplementation(() => null);
+
+    render(<UpdateProduct />);
+
+    fireEvent.click(screen.getByText("UPDATE PRODUCT")); // Trigger the update button click
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("something went wrong");
+    });
+  });
+
+  it("should delete a product successfully", async () => {
+    window.prompt = jest.fn().mockReturnValue(true);
+    axios.get.mockImplementation((url) => {
+      if (url === GET_SINGLE_PRODUCT_URL) {
+        return Promise.resolve({ data: mockProduct });
+      } else if (url === GET_ALL_CATEGORIES_URL) {
+        return Promise.resolve({
+          data: { success: true, category: mockCategories },
+        });
+      }
+    });
+    axios.delete.mockResolvedValueOnce({ data: {} });
+
+    render(<UpdateProduct />);
+
+    // Trigger the delete button click
+    fireEvent.click(screen.getByText("DELETE PRODUCT"));
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("Product DEleted Succfully");
+    });
+    expect(mockNavigate).toHaveBeenCalledWith("/dashboard/admin/products");
+    expect(axios.delete).toHaveBeenCalled();
+  });
+
+  it("should handle prompt cancel during product deletion", async () => {
+    window.prompt = jest.fn().mockReturnValue(null);
+    axios.get.mockImplementation((url) => {
+      if (url === GET_SINGLE_PRODUCT_URL) {
+        return Promise.resolve({ data: mockProduct });
+      } else if (url === GET_ALL_CATEGORIES_URL) {
+        return Promise.resolve({
+          data: { success: true, category: mockCategories },
+        });
+      }
+    });
+
+    render(<UpdateProduct />);
+
+    // Trigger the delete button click
+    fireEvent.click(screen.getByText("DELETE PRODUCT"));
+
+    await waitFor(() => {
+      expect(window.prompt).toHaveBeenCalled();
+    });
+    expect(axios.delete).not.toHaveBeenCalled();
+  });
+
+  it("should handle failure during product deletion", async () => {
+    window.prompt = jest.fn().mockReturnValue(true);
+    const mockError = new Error("Failed to delete product");
+    axios.get.mockImplementation((url) => {
+      if (url === GET_SINGLE_PRODUCT_URL) {
+        return Promise.resolve({ data: mockProduct });
+      } else if (url === GET_ALL_CATEGORIES_URL) {
+        return Promise.resolve({
+          data: { success: true, category: mockCategories },
+        });
+      }
+    });
+    axios.delete.mockRejectedValueOnce(mockError);
+
+    render(<UpdateProduct />);
+
+    // Trigger the delete button click
+    fireEvent.click(screen.getByText("DELETE PRODUCT"));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Something went wrong");
+    });
+    expect(axios.delete).toHaveBeenCalled();
+  });
+
+  it("should handle file upload", async () => {
+    const file = new File(["dummy content"], "test-photo.jpg", {
+      type: "image/jpeg",
+    });
+    URL.createObjectURL = jest.fn().mockReturnValue("test-url");
+    axios.get.mockImplementation((url) => {
+      if (url === GET_SINGLE_PRODUCT_URL) {
+        return Promise.resolve({ data: mockProduct });
+      } else if (url === GET_ALL_CATEGORIES_URL) {
+        return Promise.resolve({
+          data: { success: true, category: mockCategories },
+        });
+      }
+    });
+
+    render(<UpdateProduct />);
+
+    // Simulate file selection
+    fireEvent.change(screen.getByLabelText("Upload Photo"), {
+      target: { files: [file] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByAltText("product_photo")).toBeInTheDocument();
+    });
+  });
+
+  // TODO - Fix this test
+  //   it("should handle shipping option change", async () => {
+  //     axios.get.mockImplementation((url) => {
+  //       if (url === GET_SINGLE_PRODUCT_URL) {
+  //         return Promise.resolve({ data: mockProduct });
+  //       } else if (url === GET_ALL_CATEGORIES_URL) {
+  //         return Promise.resolve({
+  //           data: { success: true, category: mockCategories },
+  //         });
+  //       }
+  //     });
+
+  //     render(<UpdateProduct />);
+
+  //     await screen.findByDisplayValue("Test Product");
+  //     const selectElement = screen.getByRole("combobox");
+  //     fireEvent.mouseDown(selectElement);
+
+  //     const optionElement = screen.getByText("Yes");
+  //     fireEvent.click(optionElement);
+
+  //     expect(selectElement).toHaveTextContent("Yes");
+
+  //     // await waitFor(() => {
+  //     //   expect(shippingSelect.value).toBe("1");
+  //     // });
+  //   });
+});

--- a/client/src/pages/admin/Users.test.js
+++ b/client/src/pages/admin/Users.test.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+
+import Users from "./Users";
+
+// Mock dependencies
+jest.mock("../../components/Layout", () => ({ children }) => (
+  <div data-testid="layout">{children}</div>
+));
+
+jest.mock("../../components/AdminMenu", () => () => (
+  <div data-testid="admin-menu">Mock AdminMenu</div>
+));
+
+describe("Users Component", () => {
+  it("should render the Layout component with the correct title", () => {
+    render(<Users />);
+
+    // Check if the Layout component is rendered with the correct title
+    expect(screen.getByText("All Users")).toBeInTheDocument();
+    expect(screen.getByTestId("admin-menu")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
AdminOrders
- Change status into a normal array instead of state variable
- Fix typos in status (**TODO:** fix status in backend)
- Add missing `key` prop in `orders.map` list

CreateCategory
- Remove use of deprecated `visible` prop of Modal (AntDesign) and use `open` instead

UpdateProducts
- Flip the conditions in `handleUpdate` as it was reversed 
- Remove use of deprecated `bordered` prop of Select (AntDesign) and use `variant` instead 

Misc refactoring
- Move strings into exported constant
