### PR TITLE
Add admin pages unit tests

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
-        "@testing-library/user-event": "^13.5.0",
         "antd": "^5.15.0",
         "axios": "^1.6.7",
         "braintree-web-drop-in-react": "^1.2.1",
@@ -26,6 +25,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@testing-library/user-event": "^14.6.1",
         "jest": "^27.5.1"
       }
     },
@@ -4375,6 +4375,7 @@
       "version": "9.3.4",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
       "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -4394,6 +4395,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4409,6 +4411,7 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
       "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "deep-equal": "^2.0.5"
@@ -4418,6 +4421,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4434,6 +4438,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4446,12 +4451,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "peer": true
     },
     "node_modules/@testing-library/dom/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -4461,6 +4468,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -4659,14 +4667,12 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
-      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
       "engines": {
-        "node": ">=10",
+        "node": ">=12",
         "npm": ">=6"
       },
       "peerDependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
-    "@testing-library/user-event": "^13.5.0",
     "antd": "^5.15.0",
     "axios": "^1.6.7",
     "braintree-web-drop-in-react": "^1.2.1",
@@ -46,6 +45,7 @@
     ]
   },
   "devDependencies": {
+    "@testing-library/user-event": "^14.6.1",
     "jest": "^27.5.1"
   }
 }

--- a/client/src/pages/admin/CreateCategory.js
+++ b/client/src/pages/admin/CreateCategory.js
@@ -21,6 +21,13 @@ export const CREATE_CATEGORY_STRINGS = {
   CATEGORY_DELETED: "Category deleted successfully",
 };
 
+export const API_URLS = {
+  CREATE_CATEGORY: "/api/v1/category/create-category",
+  GET_CATEGORIES: "/api/v1/category/get-category",
+  UPDATE_CATEGORY: "/api/v1/category/update-category",
+  DELETE_CATEGORY: "/api/v1/category/delete-category",
+};
+
 const CreateCategory = () => {
   const [categories, setCategories] = useState([]);
   const [name, setName] = useState("");
@@ -31,7 +38,7 @@ const CreateCategory = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const { data } = await axios.post("/api/v1/category/create-category", {
+      const { data } = await axios.post(API_URLS.CREATE_CATEGORY, {
         name,
       });
       if (data?.success) {
@@ -48,7 +55,7 @@ const CreateCategory = () => {
 
   const getAllCategory = async () => {
     try {
-      const { data } = await axios.get("/api/v1/category/get-category");
+      const { data } = await axios.get(API_URLS.GET_CATEGORIES);
       if (data.success) {
         setCategories(data.category);
       } else {
@@ -68,7 +75,7 @@ const CreateCategory = () => {
     e.preventDefault();
     try {
       const { data } = await axios.put(
-        `/api/v1/category/update-category/${selected._id}`,
+        `${API_URLS.UPDATE_CATEGORY}/${selected._id}`,
         { name: updatedName }
       );
       if (data.success) {
@@ -87,9 +94,7 @@ const CreateCategory = () => {
 
   const handleDelete = async (pId) => {
     try {
-      const { data } = await axios.delete(
-        `/api/v1/category/delete-category/${pId}`
-      );
+      const { data } = await axios.delete(`${API_URLS.DELETE_CATEGORY}/${pId}`);
       if (data.success) {
         toast.success(CREATE_CATEGORY_STRINGS.CATEGORY_DELETED);
       } else {

--- a/client/src/pages/admin/CreateCategory.test.js
+++ b/client/src/pages/admin/CreateCategory.test.js
@@ -10,7 +10,10 @@ import {
 import "@testing-library/jest-dom/extend-expect";
 import axios from "axios";
 
-import CreateCategory, { CREATE_CATEGORY_STRINGS } from "./CreateCategory";
+import CreateCategory, {
+  API_URLS,
+  CREATE_CATEGORY_STRINGS,
+} from "./CreateCategory";
 
 // Mock dependencies
 jest.mock("axios");
@@ -67,7 +70,7 @@ describe("CreateCategory Component", () => {
         )
       ).toHaveLength(mockCategories.length)
     );
-    expect(axios.get).toHaveBeenCalled();
+    expect(axios.get).toHaveBeenCalledWith(API_URLS.GET_CATEGORIES);
   });
 
   it("should display error when fetching categories fails", async () => {
@@ -84,6 +87,7 @@ describe("CreateCategory Component", () => {
         /create-category-/
       )
     ).toHaveLength(0);
+    expect(axios.get).toHaveBeenCalledWith(API_URLS.GET_CATEGORIES);
   });
 
   it("should display error when fetching categories throws exception", async () => {
@@ -100,6 +104,7 @@ describe("CreateCategory Component", () => {
         /create-category-/
       )
     ).toHaveLength(0);
+    expect(axios.get).toHaveBeenCalledWith(API_URLS.GET_CATEGORIES);
   });
 
   it("should create a new category and display success message", async () => {
@@ -120,8 +125,9 @@ describe("CreateCategory Component", () => {
     );
 
     // Create a new category
+    const newCategory = "New Category";
     const input = screen.getByTestId("category-input");
-    fireEvent.change(input, { target: { value: "New Category" } });
+    fireEvent.change(input, { target: { value: newCategory } });
     fireEvent.click(screen.getByTestId("submit-button"));
 
     await waitFor(() =>
@@ -129,11 +135,11 @@ describe("CreateCategory Component", () => {
         CREATE_CATEGORY_STRINGS.CATEGORY_CREATED
       )
     );
-    expect(axios.post).toHaveBeenCalledWith(
-      "/api/v1/category/create-category",
-      { name: "New Category" }
-    );
+    expect(axios.post).toHaveBeenCalledWith(API_URLS.CREATE_CATEGORY, {
+      name: newCategory,
+    });
     expect(axios.get).toHaveBeenCalledTimes(2);
+    expect(axios.get).toHaveBeenCalledWith(API_URLS.GET_CATEGORIES);
   });
 
   it("should display error when category creation fails", async () => {
@@ -153,13 +159,22 @@ describe("CreateCategory Component", () => {
       ).toHaveLength(mockCategories.length)
     );
 
+    // Create a new category
+    const newCategory = "New Category";
+    const input = screen.getByTestId("category-input");
+    fireEvent.change(input, { target: { value: newCategory } });
     fireEvent.click(screen.getByTestId("submit-button"));
+
     await waitFor(() =>
       expect(toast.error).toHaveBeenCalledWith(
         CREATE_CATEGORY_STRINGS.CREATE_CATEGORY_ERROR
       )
     );
+    expect(axios.post).toHaveBeenCalledWith(API_URLS.CREATE_CATEGORY, {
+      name: newCategory,
+    });
     expect(axios.get).toHaveBeenCalledTimes(2);
+    expect(axios.get).toHaveBeenCalledWith(API_URLS.GET_CATEGORIES);
   });
 
   it("should display error when category creation throws exception", async () => {
@@ -179,12 +194,20 @@ describe("CreateCategory Component", () => {
       ).toHaveLength(mockCategories.length)
     );
 
+    // Create a new category
+    const newCategory = "New Category";
+    const input = screen.getByTestId("category-input");
+    fireEvent.change(input, { target: { value: newCategory } });
     fireEvent.click(screen.getByTestId("submit-button"));
+
     await waitFor(() =>
       expect(toast.error).toHaveBeenCalledWith(
         CREATE_CATEGORY_STRINGS.CREATE_CATEGORY_ERROR
       )
     );
+    expect(axios.post).toHaveBeenCalledWith(API_URLS.CREATE_CATEGORY, {
+      name: newCategory,
+    });
     expect(axios.get).toHaveBeenCalledTimes(2);
   });
 
@@ -214,9 +237,10 @@ describe("CreateCategory Component", () => {
       )
     );
     expect(axios.delete).toHaveBeenCalledWith(
-      `/api/v1/category/delete-category/${id}`
+      `${API_URLS.DELETE_CATEGORY}/${id}`
     );
     expect(axios.get).toHaveBeenCalledTimes(2);
+    expect(axios.get).toHaveBeenCalledWith(API_URLS.GET_CATEGORIES);
   });
 
   it("should display error when category deletion fails", async () => {
@@ -245,9 +269,10 @@ describe("CreateCategory Component", () => {
       )
     );
     expect(axios.delete).toHaveBeenCalledWith(
-      `/api/v1/category/delete-category/${id}`
+      `${API_URLS.DELETE_CATEGORY}/${id}`
     );
     expect(axios.get).toHaveBeenCalledTimes(2);
+    expect(axios.get).toHaveBeenCalledWith(API_URLS.GET_CATEGORIES);
   });
 
   it("should display error when category deletion throws exception", async () => {
@@ -276,9 +301,10 @@ describe("CreateCategory Component", () => {
       )
     );
     expect(axios.delete).toHaveBeenCalledWith(
-      `/api/v1/category/delete-category/${id}`
+      `${API_URLS.DELETE_CATEGORY}/${id}`
     );
     expect(axios.get).toHaveBeenCalledTimes(2);
+    expect(axios.get).toHaveBeenCalledWith(API_URLS.GET_CATEGORIES);
   });
 
   it("should update a category and display success message", async () => {
@@ -311,10 +337,11 @@ describe("CreateCategory Component", () => {
       )
     );
     expect(axios.put).toHaveBeenCalledWith(
-      `/api/v1/category/update-category/${id}`,
+      `${API_URLS.UPDATE_CATEGORY}/${id}`,
       { name: "Updated Category" }
     );
     expect(axios.get).toHaveBeenCalledTimes(2);
+    expect(axios.get).toHaveBeenCalledWith(API_URLS.GET_CATEGORIES);
   });
 
   it("should display error when category update fails", async () => {
@@ -347,10 +374,11 @@ describe("CreateCategory Component", () => {
       )
     );
     expect(axios.put).toHaveBeenCalledWith(
-      `/api/v1/category/update-category/${id}`,
+      `${API_URLS.UPDATE_CATEGORY}/${id}`,
       { name: "Updated Category" }
     );
     expect(axios.get).toHaveBeenCalledTimes(2);
+    expect(axios.get).toHaveBeenCalledWith(API_URLS.GET_CATEGORIES);
   });
 
   it("should display error when category update throws exception", async () => {
@@ -383,10 +411,11 @@ describe("CreateCategory Component", () => {
       )
     );
     expect(axios.put).toHaveBeenCalledWith(
-      `/api/v1/category/update-category/${id}`,
+      `${API_URLS.UPDATE_CATEGORY}/${id}`,
       { name: "Updated Category" }
     );
     expect(axios.get).toHaveBeenCalledTimes(2);
+    expect(axios.get).toHaveBeenCalledWith(API_URLS.GET_CATEGORIES);
   });
 
   it("should cancel modal", async () => {
@@ -410,5 +439,6 @@ describe("CreateCategory Component", () => {
 
     expect(axios.put).not.toHaveBeenCalled();
     expect(axios.get).toHaveBeenCalledTimes(1);
+    expect(axios.get).toHaveBeenCalledWith(API_URLS.GET_CATEGORIES);
   });
 });

--- a/client/src/pages/admin/CreateProduct.js
+++ b/client/src/pages/admin/CreateProduct.js
@@ -30,6 +30,11 @@ export const CREATE_PRODUCT_STRINGS = {
   PRODUCT_CREATED: "Product created successfully",
 };
 
+export const API_URLS = {
+  CREATE_PRODUCT: "/api/v1/product/create-product",
+  GET_CATEGORIES: "/api/v1/category/get-category",
+};
+
 const CreateProduct = () => {
   const navigate = useNavigate();
   const [categories, setCategories] = useState([]);
@@ -44,7 +49,7 @@ const CreateProduct = () => {
   useEffect(() => {
     const getAllCategory = async () => {
       try {
-        const { data } = await axios.get("/api/v1/category/get-category");
+        const { data } = await axios.get(API_URLS.GET_CATEGORIES);
         if (data?.success) {
           setCategories(data?.category);
         } else {
@@ -69,10 +74,7 @@ const CreateProduct = () => {
       productData.append("photo", photo);
       productData.append("category", category);
       productData.append("shipping", shipping);
-      const { data } = await axios.post(
-        "/api/v1/product/create-product",
-        productData
-      );
+      const { data } = await axios.post(API_URLS.CREATE_PRODUCT, productData);
       if (data?.success) {
         toast.success(CREATE_PRODUCT_STRINGS.PRODUCT_CREATED);
         navigate("/dashboard/admin/products");
@@ -104,18 +106,20 @@ const CreateProduct = () => {
                 onChange={(value) => {
                   setCategory(value);
                 }}
+                data-testid="create-product-category-select"
               >
                 {categories?.map((c) => (
-                  <Option key={c._id} value={c._id}>
+                  <Option
+                    key={c._id}
+                    value={c._id}
+                    data-testid={`create-product-option-${c._id}`}
+                  >
                     {c.name}
                   </Option>
                 ))}
               </Select>
               <div className="mb-3">
-                <label
-                  className="btn btn-outline-secondary col-md-12"
-                  data-testid="create-product-photo-input"
-                >
+                <label className="btn btn-outline-secondary col-md-12">
                   {photo
                     ? photo.name
                     : CREATE_PRODUCT_STRINGS.UPLOAD_PHOTO_ACTION}
@@ -125,6 +129,7 @@ const CreateProduct = () => {
                     accept="image/*"
                     onChange={(e) => setPhoto(e.target.files[0])}
                     hidden
+                    data-testid="create-product-photo-input"
                   />
                 </label>
               </div>
@@ -193,13 +198,14 @@ const CreateProduct = () => {
                   showSearch
                   className="form-select mb-3"
                   onChange={(value) => {
-                    setShipping(value);
+                    setShipping(value === "true");
                   }}
+                  data-testid="create-product-shipping-select"
                 >
-                  <Option value="0">
+                  <Option value="false">
                     {CREATE_PRODUCT_STRINGS.SELECT_SHIPPING_NO_ACTION}
                   </Option>
-                  <Option value="1">
+                  <Option value="true">
                     {CREATE_PRODUCT_STRINGS.SELECT_SHIPPING_YES_ACTION}
                   </Option>
                 </Select>

--- a/client/src/pages/admin/CreateProduct.js
+++ b/client/src/pages/admin/CreateProduct.js
@@ -5,7 +5,30 @@ import toast from "react-hot-toast";
 import axios from "axios";
 import { Select } from "antd";
 import { useNavigate } from "react-router-dom";
+
 const { Option } = Select;
+
+export const CREATE_PRODUCT_STRINGS = {
+  CREATE_PRODUCT_ACTION: "CREATE PRODUCT",
+  DELETE_PRODUCT_ACTION: "DELETE PRODUCT",
+  SELECT_CATEGORY_ACTION: "Select a category",
+  SELECT_SHIPPING_ACTION: "Select Shipping",
+  SELECT_SHIPPING_YES_ACTION: "Yes",
+  SELECT_SHIPPING_NO_ACTION: "No",
+  UPLOAD_PHOTO_ACTION: "Upload Photo",
+  DELETE_PRODUCT_CONFIRM:
+    "Delete Product? Enter any key to confirm. This action is irreversible.",
+
+  PRODUCT_NAME_PLACEHOLDER: "Enter name",
+  PRODUCT_DESCRIPTION_PLACEHOLDER: "Enter description",
+  PRODUCT_PRICE_PLACEHOLDER: "Enter price",
+  PRODUCT_QUANTITY_PLACEHOLDER: "Enter quantity",
+
+  FETCH_PRODUCT_ERROR: "Something went wrong in getting product",
+  FETCH_CATEGORY_ERROR: "Something went wrong in getting category",
+  CREATE_PRODUCT_ERROR: "Something went wrong in creating product",
+  PRODUCT_CREATED: "Product created successfully",
+};
 
 const CreateProduct = () => {
   const navigate = useNavigate();
@@ -18,24 +41,23 @@ const CreateProduct = () => {
   const [shipping, setShipping] = useState("");
   const [photo, setPhoto] = useState("");
 
-  //get all category
-  const getAllCategory = async () => {
-    try {
-      const { data } = await axios.get("/api/v1/category/get-category");
-      if (data?.success) {
-        setCategories(data?.category);
-      }
-    } catch (error) {
-      console.log(error);
-      toast.error("Something wwent wrong in getting catgeory");
-    }
-  };
-
   useEffect(() => {
+    const getAllCategory = async () => {
+      try {
+        const { data } = await axios.get("/api/v1/category/get-category");
+        if (data?.success) {
+          setCategories(data?.category);
+        } else {
+          throw new Error("Error in getting category");
+        }
+      } catch (error) {
+        toast.error(CREATE_PRODUCT_STRINGS.FETCH_CATEGORY_ERROR);
+        console.log(error);
+      }
+    };
     getAllCategory();
   }, []);
 
-  //create product function
   const handleCreate = async (e) => {
     e.preventDefault();
     try {
@@ -46,19 +68,20 @@ const CreateProduct = () => {
       productData.append("quantity", quantity);
       productData.append("photo", photo);
       productData.append("category", category);
-      const { data } = axios.post(
+      productData.append("shipping", shipping);
+      const { data } = await axios.post(
         "/api/v1/product/create-product",
         productData
       );
       if (data?.success) {
-        toast.error(data?.message);
-      } else {
-        toast.success("Product Created Successfully");
+        toast.success(CREATE_PRODUCT_STRINGS.PRODUCT_CREATED);
         navigate("/dashboard/admin/products");
+      } else {
+        throw new Error("Error in creating product");
       }
     } catch (error) {
+      toast.error(CREATE_PRODUCT_STRINGS.CREATE_PRODUCT_ERROR);
       console.log(error);
-      toast.error("something went wrong");
     }
   };
 
@@ -73,7 +96,7 @@ const CreateProduct = () => {
             <h1>Create Product</h1>
             <div className="m-1 w-75">
               <Select
-                bordered={false}
+                variant="borderless"
                 placeholder="Select a category"
                 size="large"
                 showSearch
@@ -89,8 +112,13 @@ const CreateProduct = () => {
                 ))}
               </Select>
               <div className="mb-3">
-                <label className="btn btn-outline-secondary col-md-12">
-                  {photo ? photo.name : "Upload Photo"}
+                <label
+                  className="btn btn-outline-secondary col-md-12"
+                  data-testid="create-product-photo-input"
+                >
+                  {photo
+                    ? photo.name
+                    : CREATE_PRODUCT_STRINGS.UPLOAD_PHOTO_ACTION}
                   <input
                     type="file"
                     name="photo"
@@ -116,18 +144,22 @@ const CreateProduct = () => {
                 <input
                   type="text"
                   value={name}
-                  placeholder="write a name"
+                  placeholder={CREATE_PRODUCT_STRINGS.PRODUCT_NAME_PLACEHOLDER}
                   className="form-control"
                   onChange={(e) => setName(e.target.value)}
+                  data-testid="create-product-name-input"
                 />
               </div>
               <div className="mb-3">
                 <textarea
                   type="text"
                   value={description}
-                  placeholder="write a description"
+                  placeholder={
+                    CREATE_PRODUCT_STRINGS.PRODUCT_DESCRIPTION_PLACEHOLDER
+                  }
                   className="form-control"
                   onChange={(e) => setDescription(e.target.value)}
+                  data-testid="create-product-description-input"
                 />
               </div>
 
@@ -135,24 +167,28 @@ const CreateProduct = () => {
                 <input
                   type="number"
                   value={price}
-                  placeholder="write a Price"
+                  placeholder={CREATE_PRODUCT_STRINGS.PRODUCT_PRICE_PLACEHOLDER}
                   className="form-control"
                   onChange={(e) => setPrice(e.target.value)}
+                  data-testid="create-product-price-input"
                 />
               </div>
               <div className="mb-3">
                 <input
                   type="number"
                   value={quantity}
-                  placeholder="write a quantity"
+                  placeholder={
+                    CREATE_PRODUCT_STRINGS.PRODUCT_QUANTITY_PLACEHOLDER
+                  }
                   className="form-control"
                   onChange={(e) => setQuantity(e.target.value)}
+                  data-testid="create-product-quantity-input"
                 />
               </div>
               <div className="mb-3">
                 <Select
-                  bordered={false}
-                  placeholder="Select Shipping "
+                  variant="borderless"
+                  placeholder={CREATE_PRODUCT_STRINGS.SELECT_SHIPPING_ACTION}
                   size="large"
                   showSearch
                   className="form-select mb-3"
@@ -160,13 +196,21 @@ const CreateProduct = () => {
                     setShipping(value);
                   }}
                 >
-                  <Option value="0">No</Option>
-                  <Option value="1">Yes</Option>
+                  <Option value="0">
+                    {CREATE_PRODUCT_STRINGS.SELECT_SHIPPING_NO_ACTION}
+                  </Option>
+                  <Option value="1">
+                    {CREATE_PRODUCT_STRINGS.SELECT_SHIPPING_YES_ACTION}
+                  </Option>
                 </Select>
               </div>
               <div className="mb-3">
-                <button className="btn btn-primary" onClick={handleCreate}>
-                  CREATE PRODUCT
+                <button
+                  className="btn btn-primary"
+                  onClick={handleCreate}
+                  data-testid="create-product-button"
+                >
+                  {CREATE_PRODUCT_STRINGS.CREATE_PRODUCT_ACTION}
                 </button>
               </div>
             </div>

--- a/client/src/pages/admin/CreateProduct.test.js
+++ b/client/src/pages/admin/CreateProduct.test.js
@@ -1,0 +1,236 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import toast from "react-hot-toast";
+import {
+  act,
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import "@testing-library/jest-dom/extend-expect";
+import axios from "axios";
+
+import CreateProduct, {
+  CREATE_PRODUCT_STRINGS,
+  API_URLS,
+} from "./CreateProduct";
+
+// Mock dependencies
+jest.mock("axios");
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: jest.fn(),
+}));
+
+jest.mock("react-hot-toast", () => ({
+  error: jest.fn(),
+  success: jest.fn(),
+}));
+
+jest.mock("antd", () => {
+  const actualAntd = jest.requireActual("antd");
+  const MockSelect = ({ children, onChange, "data-testid": testId }) => (
+    <select data-testid={testId} onChange={(e) => onChange(e.target.value)}>
+      {children}
+    </select>
+  );
+
+  MockSelect.Option = ({ children, value, "data-testid": testId }) => (
+    <option value={value} data-testid={testId}>
+      {children}
+    </option>
+  );
+
+  return { ...actualAntd, Select: MockSelect };
+});
+
+jest.mock("../../components/Layout", () => ({ children }) => (
+  <div data-testid="layout">{children}</div>
+));
+
+jest.mock("../../components/AdminMenu", () => () => (
+  <div data-testid="admin-menu">Mock AdminMenu</div>
+));
+
+describe("CreateProduct Component", () => {
+  const mockCategories = [{ _id: "1", name: "Electronics" }];
+  const mockNavigate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useNavigate.mockReturnValue(mockNavigate);
+  });
+
+  it("should fetch categories on mount", async () => {
+    axios.get.mockResolvedValue({
+      data: { success: true, category: mockCategories },
+    });
+
+    render(<CreateProduct />);
+
+    await waitFor(() =>
+      expect(
+        within(
+          screen.getByTestId("create-product-category-select")
+        ).queryAllByTestId(/create-product-option/)
+      ).toHaveLength(mockCategories.length)
+    );
+    expect(axios.get).toHaveBeenCalledWith(API_URLS.GET_CATEGORIES);
+  });
+
+  it("should show error toast if fetching categories fails", async () => {
+    axios.get.mockResolvedValue({ data: { success: false } });
+
+    render(<CreateProduct />);
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        CREATE_PRODUCT_STRINGS.FETCH_CATEGORY_ERROR
+      )
+    );
+    expect(
+      within(
+        screen.getByTestId("create-product-category-select")
+      ).queryAllByTestId(/create-product-option/)
+    ).toHaveLength(0);
+    expect(axios.get).toHaveBeenCalledWith(API_URLS.GET_CATEGORIES);
+  });
+
+  it("should show error toast if fetching categories throws exception", async () => {
+    axios.get.mockRejectedValue(new Error("Fetch error"));
+
+    render(<CreateProduct />);
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        CREATE_PRODUCT_STRINGS.FETCH_CATEGORY_ERROR
+      )
+    );
+    expect(
+      within(
+        screen.getByTestId("create-product-category-select")
+      ).queryAllByTestId(/create-product-option/)
+    ).toHaveLength(0);
+    expect(axios.get).toHaveBeenCalledWith(API_URLS.GET_CATEGORIES);
+  });
+
+  it("should update input fields and create a product", async () => {
+    const user = userEvent.setup();
+    const inputFormData = {
+      name: "New Product",
+      description: "New Description",
+      price: "200",
+      quantity: "10",
+      photo: new File(["dummy content"], "test-photo.jpg", {
+        type: "image/jpeg",
+      }),
+      category: mockCategories[0]._id,
+      shipping: "false",
+    };
+    URL.createObjectURL = jest.fn().mockReturnValue("test-url");
+    axios.get.mockResolvedValue({
+      data: { success: true, category: mockCategories },
+    });
+    axios.post.mockResolvedValue({ data: { success: true } });
+
+    render(<CreateProduct />);
+
+    // Wait for categories to be displayed
+    await waitFor(() =>
+      expect(
+        within(
+          screen.getByTestId("create-product-category-select")
+        ).queryAllByTestId(/create-product-option/)
+      ).toHaveLength(mockCategories.length)
+    );
+
+    // Fill form and submit
+    fireEvent.change(screen.getByTestId("create-product-name-input"), {
+      target: { value: inputFormData.name },
+    });
+    fireEvent.change(screen.getByTestId("create-product-description-input"), {
+      target: { value: inputFormData.description },
+    });
+    fireEvent.change(screen.getByTestId("create-product-price-input"), {
+      target: { value: inputFormData.price },
+    });
+    fireEvent.change(screen.getByTestId("create-product-quantity-input"), {
+      target: { value: inputFormData.quantity },
+    });
+    fireEvent.change(screen.getByTestId("create-product-category-select"), {
+      target: { value: inputFormData.category },
+    });
+    fireEvent.change(screen.getByTestId("create-product-shipping-select"), {
+      target: { value: inputFormData.shipping },
+    });
+    const uploadInput = screen.getByTestId("create-product-photo-input");
+    await act(async () => {
+      await user.upload(uploadInput, inputFormData.photo);
+    });
+    await waitFor(() => {
+      expect(uploadInput.files).toHaveLength(1);
+    });
+    fireEvent.click(screen.getByTestId("create-product-button"));
+
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith(
+        CREATE_PRODUCT_STRINGS.PRODUCT_CREATED
+      )
+    );
+    expect(mockNavigate).toHaveBeenCalledWith("/dashboard/admin/products");
+    expect(axios.post).toHaveBeenCalledWith(
+      API_URLS.CREATE_PRODUCT,
+      expect.any(FormData)
+    );
+    const actualFormData = axios.post.mock.calls[0][1];
+    Object.entries(inputFormData).forEach(([key, value]) => {
+      expect(actualFormData.get(key)).toBe(value);
+    });
+  });
+
+  it("should handle product creation failure", async () => {
+    axios.get.mockResolvedValue({
+      data: { success: true, category: mockCategories },
+    });
+    axios.post.mockResolvedValue({ data: { success: false } });
+
+    render(<CreateProduct />);
+    fireEvent.click(screen.getByTestId("create-product-button"));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        CREATE_PRODUCT_STRINGS.CREATE_PRODUCT_ERROR
+      )
+    );
+    expect(axios.post).toHaveBeenCalledWith(
+      API_URLS.CREATE_PRODUCT,
+      expect.any(FormData)
+    );
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("should handle product creation throws exception", async () => {
+    axios.get.mockResolvedValue({
+      data: { success: true, category: mockCategories },
+    });
+    axios.post.mockRejectedValue(new Error("Create error"));
+
+    render(<CreateProduct />);
+    fireEvent.click(screen.getByTestId("create-product-button"));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        CREATE_PRODUCT_STRINGS.CREATE_PRODUCT_ERROR
+      )
+    );
+    expect(axios.post).toHaveBeenCalledWith(
+      API_URLS.CREATE_PRODUCT,
+      expect.any(FormData)
+    );
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/pages/admin/Products.js
+++ b/client/src/pages/admin/Products.js
@@ -9,13 +9,18 @@ export const PRODUCTS_STRINGS = {
   FETCH_PRODUCTS_ERROR: "Someething went wrong while fetching products",
 };
 
+export const API_URLS = {
+  GET_PRODUCTS: "/api/v1/product/get-product",
+  GET_PHOTO: "/api/v1/product/product-photo",
+};
+
 const Products = () => {
   const [products, setProducts] = useState([]);
 
   useEffect(() => {
     const getAllProducts = async () => {
       try {
-        const { data } = await axios.get("/api/v1/product/get-product");
+        const { data } = await axios.get(API_URLS.GET_PRODUCTS);
         setProducts(data.products);
       } catch (error) {
         toast.error(PRODUCTS_STRINGS.FETCH_PRODUCTS_ERROR);
@@ -47,7 +52,7 @@ const Products = () => {
                   data-testid={`admin-product-${index}`}
                 >
                   <img
-                    src={`/api/v1/product/product-photo/${p._id}`}
+                    src={`${API_URLS.GET_PHOTO}/${p._id}`}
                     className="card-img-top"
                     alt={p.name}
                   />

--- a/client/src/pages/admin/Products.test.js
+++ b/client/src/pages/admin/Products.test.js
@@ -4,7 +4,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
 import axios from "axios";
 
-import Products, { PRODUCTS_STRINGS } from "./Products";
+import Products, { API_URLS, PRODUCTS_STRINGS } from "./Products";
 
 // Mock dependencies
 jest.mock("axios");
@@ -58,7 +58,7 @@ describe("Products Component", () => {
         )
       ).toHaveLength(mockProducts.length)
     );
-    expect(axios.get).toHaveBeenCalled();
+    expect(axios.get).toHaveBeenCalledWith(API_URLS.GET_PRODUCTS);
   });
 
   it("should display no products when API returns an empty array", async () => {
@@ -73,7 +73,7 @@ describe("Products Component", () => {
         )
       ).toHaveLength(0)
     );
-    expect(axios.get).toHaveBeenCalled();
+    expect(axios.get).toHaveBeenCalledWith(API_URLS.GET_PRODUCTS);
   });
 
   it("should display an error message when API call fails", async () => {
@@ -89,7 +89,7 @@ describe("Products Component", () => {
         )
       ).toHaveLength(0)
     );
-    expect(axios.get).toHaveBeenCalled();
+    expect(axios.get).toHaveBeenCalledWith(API_URLS.GET_PRODUCTS);
     expect(toast.error).toHaveBeenCalledWith(
       PRODUCTS_STRINGS.FETCH_PRODUCTS_ERROR
     );

--- a/client/src/pages/admin/UpdateProduct.js
+++ b/client/src/pages/admin/UpdateProduct.js
@@ -34,9 +34,10 @@ export const UPDATE_PRODUCT_STRINGS = {
 
 export const API_URLS = {
   GET_PRODUCT: "/api/v1/product/get-product",
-  GET_CATEGORY: "/api/v1/category/get-category",
+  GET_CATEGORIES: "/api/v1/category/get-category",
   UPDATE_PRODUCT: "/api/v1/product/update-product",
   DELETE_PRODUCT: "/api/v1/product/delete-product",
+  GET_PRODUCT_PHOTO: "/api/v1/product/product-photo",
 };
 
 const UpdateProduct = () => {
@@ -80,7 +81,7 @@ const UpdateProduct = () => {
   useEffect(() => {
     const getAllCategory = async () => {
       try {
-        const { data } = await axios.get(API_URLS.GET_CATEGORY);
+        const { data } = await axios.get(API_URLS.GET_CATEGORIES);
         if (!data?.success) {
           throw new Error("Error in getting category");
         }
@@ -196,7 +197,7 @@ const UpdateProduct = () => {
                 ) : (
                   <div className="text-center">
                     <img
-                      src={`/api/v1/product/product-photo/${id}`}
+                      src={`${API_URLS.GET_PRODUCT_PHOTO}/${id}`}
                       alt="product_photo"
                       height={"200px"}
                       className="img img-responsive"

--- a/client/src/pages/admin/UpdateProduct.js
+++ b/client/src/pages/admin/UpdateProduct.js
@@ -106,7 +106,8 @@ const UpdateProduct = () => {
       productData.append("quantity", quantity);
       photo && productData.append("photo", photo);
       productData.append("category", category);
-      const { data } = axios.put(
+      productData.append("shipping", shipping);
+      const { data } = await axios.put(
         `${API_URLS.UPDATE_PRODUCT}/${id}`,
         productData
       );
@@ -168,21 +169,19 @@ const UpdateProduct = () => {
                 ))}
               </Select>
               <div className="mb-3">
-                <label
-                  className="btn btn-outline-secondary col-md-12"
-                  data-testid="admin-upload-photo-button"
-                >
+                <label className="btn btn-outline-secondary col-md-12">
                   {photo
                     ? photo.name
                     : UPDATE_PRODUCT_STRINGS.UPLOAD_PHOTO_ACTION}
-                  <input
-                    type="file"
-                    name="photo"
-                    accept="image/*"
-                    onChange={(e) => setPhoto(e.target.files[0])}
-                    hidden
-                  />
                 </label>
+                <input
+                  type="file"
+                  name="photo"
+                  accept="image/*"
+                  onChange={(e) => setPhoto(e.target.files[0])}
+                  data-testid="admin-update-product-photo-input"
+                  hidden
+                />
               </div>
               <div className="mb-3">
                 {photo ? (

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@babel/preset-react": "^7.24.1",
         "@playwright/test": "^1.44.0",
         "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^20.12.12",
         "babel-jest": "^29.7.0",
         "identity-obj-proxy": "^3.0.0",
@@ -2227,6 +2228,78 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.6.3",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
@@ -2262,6 +2335,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -2270,6 +2356,13 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3400,6 +3493,16 @@
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/destroy": {
@@ -5334,6 +5437,16 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/make-dir": {
@@ -9126,6 +9239,68 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "@testing-library/dom": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true,
+          "peer": true
+        },
+        "aria-query": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+          "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "dequal": "^2.0.3"
+          }
+        },
+        "dom-accessibility-api": {
+          "version": "0.5.16",
+          "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+          "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+          "dev": true,
+          "peer": true
+        },
+        "pretty-format": {
+          "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+          "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true,
+          "peer": true
+        }
+      }
+    },
     "@testing-library/jest-dom": {
       "version": "6.6.3",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
@@ -9153,11 +9328,25 @@
         }
       }
     },
+    "@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "requires": {}
+    },
     "@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true
+    },
+    "@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "peer": true
     },
     "@types/babel__core": {
       "version": "7.20.5",
@@ -10009,6 +10198,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+    },
+    "dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "peer": true
     },
     "destroy": {
       "version": "1.2.0",
@@ -11456,6 +11652,13 @@
       "requires": {
         "yallist": "^3.0.2"
       }
+    },
+    "lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "peer": true
     },
     "make-dir": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@babel/preset-react": "^7.24.1",
     "@playwright/test": "^1.44.0",
     "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20.12.12",
     "babel-jest": "^29.7.0",
     "identity-obj-proxy": "^3.0.0",
@@ -48,8 +49,11 @@
     "sonarqube-scanner": "^3.3.0"
   },
   "jest": {
-  "coverageReporters": ["lcov", "text"],
-  "collectCoverage": true,
-  "coverageDirectory": "coverage"
-}
+    "coverageReporters": [
+      "lcov",
+      "text"
+    ],
+    "collectCoverage": true,
+    "coverageDirectory": "coverage"
+  }
 }


### PR DESCRIPTION
<img width="1279" alt="image" src="https://github.com/user-attachments/assets/7c359ef1-cab7-45c1-9682-6eae8dd698cc" />


CreateProduct
- Add `shipping` field to create product form data
- Remove use of deprecated `bordered` prop of Select (AntDesign) and use `variant` instead
- Flip the conditions in handleCreate as it was reversed