### PR TITLE
Use useCategory hook for fetching categories in admin pages

### DIFF
--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -10,7 +10,7 @@ import "../styles/Header.css";
 const Header = () => {
   const [auth, setAuth] = useAuth();
   const [cart] = useCart();
-  const categories = useCategory();
+  const [categories] = useCategory();
   const handleLogout = () => {
     setAuth({
       ...auth,

--- a/client/src/components/Header.test.js
+++ b/client/src/components/Header.test.js
@@ -6,6 +6,7 @@ import { useCart } from "../context/cart";
 import Header from "./Header";
 import toast from "react-hot-toast";
 import "@testing-library/jest-dom";
+import useCategory from "../hooks/useCategory";
 
 jest.mock("../context/auth", () => ({
   useAuth: jest.fn(),
@@ -24,26 +25,31 @@ jest.mock("react-hot-toast", () => ({
   error: jest.fn(),
 }));
 
-jest.mock("../hooks/useCategory", () =>
-  jest.fn(() => [
-    {
-      _id: "123451",
-      name: "Electronics",
-      slug: "electronics",
-      __v: 0,
-    },
-    {
-      _id: "123452",
-      name: "Fashion",
-      slug: "fashion",
-      __v: 0,
-    },
-  ])
-);
+jest.mock("../hooks/useCategory", () => ({
+  __esModule: true,
+  default: jest.fn(() => [[], jest.fn()]),
+}));
 
 describe("Header Component", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    useCategory.mockReturnValue([
+      [
+        {
+          _id: "123451",
+          name: "Electronics",
+          slug: "electronics",
+          __v: 0,
+        },
+        {
+          _id: "123452",
+          name: "Fashion",
+          slug: "fashion",
+          __v: 0,
+        },
+      ],
+      jest.fn(),
+    ]);
   });
 
   beforeAll(() => {

--- a/client/src/hooks/useCategory.js
+++ b/client/src/hooks/useCategory.js
@@ -21,6 +21,5 @@ export default function useCategory() {
     getCategories();
   }, []);
 
-  // TODO Update all old usages of this hook to use the new return value
   return [categories, refreshCategories];
 }

--- a/client/src/hooks/useCategory.js
+++ b/client/src/hooks/useCategory.js
@@ -4,7 +4,6 @@ import axios from "axios";
 export default function useCategory() {
   const [categories, setCategories] = useState([]);
 
-  //get cat
   const getCategories = async () => {
     try {
       const { data } = await axios.get("/api/v1/category/get-category");
@@ -14,9 +13,14 @@ export default function useCategory() {
     }
   };
 
+  const refreshCategories = () => {
+    getCategories();
+  };
+
   useEffect(() => {
     getCategories();
   }, []);
 
-  return categories;
+  // TODO Update all old usages of this hook to use the new return value
+  return [categories, refreshCategories];
 }

--- a/client/src/hooks/useCategory.test.js
+++ b/client/src/hooks/useCategory.test.js
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor, act } from "@testing-library/react";
 import axios from "axios";
 
 import useCategory from "./useCategory";
@@ -18,9 +18,10 @@ describe("useCategory Hook", () => {
   });
 
   it("should return an empty array by default", () => {
-    const { result } = renderHook(useCategory);
+    const { result } = renderHook(() => useCategory());
 
-    expect(result.current).toEqual([]);
+    expect(result.current[0]).toEqual([]); // categories should be an empty array
+    expect(typeof result.current[1]).toBe("function"); // refreshCategories should be a function
   });
 
   it("should fetch categories successfully", async () => {
@@ -30,24 +31,55 @@ describe("useCategory Hook", () => {
     ];
     axios.get.mockResolvedValueOnce({ data: { category: mockCategories } });
 
-    const { result } = renderHook(useCategory);
+    const { result } = renderHook(() => useCategory());
 
     await waitFor(() => {
-      expect(result.current).toEqual(mockCategories);
+      expect(result.current[0]).toEqual(mockCategories);
     });
-    expect(axios.get).toHaveBeenCalled();
+
+    expect(axios.get).toHaveBeenCalledTimes(1); // API should be called on mount
   });
 
   it("should handle API failure gracefully", async () => {
     const mockError = new Error("Failed to fetch categories");
     axios.get.mockRejectedValueOnce(mockError);
 
-    const { result } = renderHook(useCategory);
+    const { result } = renderHook(() => useCategory());
 
     await waitFor(() => {
       expect(consoleLogSpy).toHaveBeenCalledWith(mockError);
     });
-    expect(axios.get).toHaveBeenCalled();
-    expect(result.current).toEqual([]); // Should remain an empty array on failure
+
+    expect(axios.get).toHaveBeenCalledTimes(1);
+    expect(result.current[0]).toEqual([]); // Should remain an empty array on failure
+  });
+
+  it("should refresh categories when refreshCategories is called", async () => {
+    const initialCategories = [{ _id: "1", name: "Initial Category" }];
+    const updatedCategories = [
+      { _id: "2", name: "Updated Category 1" },
+      { _id: "3", name: "Updated Category 2" },
+    ];
+
+    axios.get.mockResolvedValueOnce({ data: { category: initialCategories } });
+
+    // result is an array with two values: [categories, refreshCategories]
+    const { result } = renderHook(() => useCategory());
+
+    await waitFor(() => {
+      expect(result.current[0]).toEqual(initialCategories);
+    });
+
+    axios.get.mockResolvedValueOnce({ data: { category: updatedCategories } });
+
+    act(() => {
+      result.current[1]();
+    });
+
+    await waitFor(() => {
+      expect(result.current[0]).toEqual(updatedCategories);
+    });
+
+    expect(axios.get).toHaveBeenCalledTimes(2); // API should be called twice (initial + refresh)
   });
 });

--- a/client/src/pages/Categories.js
+++ b/client/src/pages/Categories.js
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import useCategory from "../hooks/useCategory";
 import Layout from "../components/Layout";
 const Categories = () => {
-  const categories = useCategory();
+  const [categories] = useCategory();
   return (
     <Layout title={"All Categories"}>
       <div className="container">

--- a/client/src/pages/admin/CreateCategory.js
+++ b/client/src/pages/admin/CreateCategory.js
@@ -1,10 +1,11 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import Layout from "./../../components/Layout";
 import AdminMenu from "./../../components/AdminMenu";
 import toast from "react-hot-toast";
 import axios from "axios";
 import CategoryForm from "../../components/Form/CategoryForm";
 import { Modal } from "antd";
+import useCategory from "../../hooks/useCategory";
 
 export const CREATE_CATEGORY_STRINGS = {
   CREATE_CATEGORY_ACTION: "Create Category",
@@ -12,7 +13,6 @@ export const CREATE_CATEGORY_STRINGS = {
   DELETE_CATEGORY_ACTION: "Delete",
 
   CREATE_CATEGORY_ERROR: "Something went wrong in creating category",
-  FETCH_CATEGORY_ERROR: "Something went wrong in getting category",
   UPDATE_CATEGORY_ERROR: "Something went wrong in updating category",
   DELETE_CATEGORY_ERROR: "Something went wrong in deleting category",
 
@@ -23,13 +23,12 @@ export const CREATE_CATEGORY_STRINGS = {
 
 export const API_URLS = {
   CREATE_CATEGORY: "/api/v1/category/create-category",
-  GET_CATEGORIES: "/api/v1/category/get-category",
   UPDATE_CATEGORY: "/api/v1/category/update-category",
   DELETE_CATEGORY: "/api/v1/category/delete-category",
 };
 
 const CreateCategory = () => {
-  const [categories, setCategories] = useState([]);
+  const [categories, refreshCategories] = useCategory();
   const [name, setName] = useState("");
   const [visible, setVisible] = useState(false);
   const [selected, setSelected] = useState(null);
@@ -50,26 +49,8 @@ const CreateCategory = () => {
       toast.error(CREATE_CATEGORY_STRINGS.CREATE_CATEGORY_ERROR);
       console.log(error);
     }
-    getAllCategory();
+    refreshCategories();
   };
-
-  const getAllCategory = async () => {
-    try {
-      const { data } = await axios.get(API_URLS.GET_CATEGORIES);
-      if (data.success) {
-        setCategories(data.category);
-      } else {
-        throw new Error("Error in getting category");
-      }
-    } catch (error) {
-      toast.error(CREATE_CATEGORY_STRINGS.FETCH_CATEGORY_ERROR);
-      console.log(error);
-    }
-  };
-
-  useEffect(() => {
-    getAllCategory();
-  }, []);
 
   const handleUpdate = async (e) => {
     e.preventDefault();
@@ -89,7 +70,7 @@ const CreateCategory = () => {
     } catch (error) {
       toast.error(CREATE_CATEGORY_STRINGS.UPDATE_CATEGORY_ERROR);
     }
-    getAllCategory();
+    refreshCategories();
   };
 
   const handleDelete = async (pId) => {
@@ -103,7 +84,7 @@ const CreateCategory = () => {
     } catch (error) {
       toast.error(CREATE_CATEGORY_STRINGS.DELETE_CATEGORY_ERROR);
     }
-    getAllCategory();
+    refreshCategories();
   };
 
   return (
@@ -132,7 +113,7 @@ const CreateCategory = () => {
                 </thead>
                 <tbody data-testid="create-category-list">
                   {categories?.map((c) => (
-                    <tr key={c._id} data-testid={`create-category-${c._id}`}>
+                    <tr key={c._id}>
                       <td>{c.name}</td>
                       <td>
                         <button

--- a/client/src/pages/admin/CreateProduct.js
+++ b/client/src/pages/admin/CreateProduct.js
@@ -1,10 +1,11 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import Layout from "./../../components/Layout";
 import AdminMenu from "./../../components/AdminMenu";
 import toast from "react-hot-toast";
 import axios from "axios";
 import { Select } from "antd";
 import { useNavigate } from "react-router-dom";
+import useCategory from "../../hooks/useCategory";
 
 const { Option } = Select;
 
@@ -32,12 +33,11 @@ export const CREATE_PRODUCT_STRINGS = {
 
 export const API_URLS = {
   CREATE_PRODUCT: "/api/v1/product/create-product",
-  GET_CATEGORIES: "/api/v1/category/get-category",
 };
 
 const CreateProduct = () => {
   const navigate = useNavigate();
-  const [categories, setCategories] = useState([]);
+  const [categories] = useCategory();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [price, setPrice] = useState("");
@@ -45,23 +45,6 @@ const CreateProduct = () => {
   const [quantity, setQuantity] = useState("");
   const [shipping, setShipping] = useState("");
   const [photo, setPhoto] = useState("");
-
-  useEffect(() => {
-    const getAllCategory = async () => {
-      try {
-        const { data } = await axios.get(API_URLS.GET_CATEGORIES);
-        if (data?.success) {
-          setCategories(data?.category);
-        } else {
-          throw new Error("Error in getting category");
-        }
-      } catch (error) {
-        toast.error(CREATE_PRODUCT_STRINGS.FETCH_CATEGORY_ERROR);
-        console.log(error);
-      }
-    };
-    getAllCategory();
-  }, []);
 
   const handleCreate = async (e) => {
     e.preventDefault();

--- a/client/src/pages/admin/UpdateProduct.js
+++ b/client/src/pages/admin/UpdateProduct.js
@@ -5,6 +5,7 @@ import toast from "react-hot-toast";
 import axios from "axios";
 import { Select } from "antd";
 import { useNavigate, useParams } from "react-router-dom";
+import useCategory from "../../hooks/useCategory";
 const { Option } = Select;
 
 export const UPDATE_PRODUCT_STRINGS = {
@@ -24,7 +25,6 @@ export const UPDATE_PRODUCT_STRINGS = {
   PRODUCT_QUANTITY_PLACEHOLDER: "write a quantity",
 
   FETCH_PRODUCT_ERROR: "Something went wrong in getting product",
-  FETCH_CATEGORY_ERROR: "Something went wrong in getting category",
   UPDATE_PRODUCT_ERROR: "Something went wrong in updating product",
   DELETE_PRODUCT_ERROR: "Something went wrong in deleting product",
 
@@ -34,7 +34,6 @@ export const UPDATE_PRODUCT_STRINGS = {
 
 export const API_URLS = {
   GET_PRODUCT: "/api/v1/product/get-product",
-  GET_CATEGORIES: "/api/v1/category/get-category",
   UPDATE_PRODUCT: "/api/v1/product/update-product",
   DELETE_PRODUCT: "/api/v1/product/delete-product",
   GET_PRODUCT_PHOTO: "/api/v1/product/product-photo",
@@ -43,7 +42,7 @@ export const API_URLS = {
 const UpdateProduct = () => {
   const navigate = useNavigate();
   const params = useParams();
-  const [categories, setCategories] = useState([]);
+  const [categories] = useCategory();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [price, setPrice] = useState("");
@@ -76,25 +75,6 @@ const UpdateProduct = () => {
 
     getSingleProduct();
   }, [params.slug]);
-
-  // Fetch all categories on component mount
-  useEffect(() => {
-    const getAllCategory = async () => {
-      try {
-        const { data } = await axios.get(API_URLS.GET_CATEGORIES);
-        if (!data?.success) {
-          throw new Error("Error in getting category");
-        }
-
-        setCategories(data?.category);
-      } catch (error) {
-        console.log(error);
-        toast.error(UPDATE_PRODUCT_STRINGS.FETCH_CATEGORY_ERROR);
-      }
-    };
-
-    getAllCategory();
-  }, []);
 
   // Create product function
   const handleUpdate = async (e) => {


### PR DESCRIPTION
- Updated `useCategory` hook to include a refresh callback
- Use the hook in admin/pages
- Update existing uses of the hook (except in [`src/pages/Categories`](https://github.com/cs4218/cs4218-2420-ecom-project-team25/blob/main/client/src/pages/Categories.js))

# TODO

- [ ] Update use of hook in [`src/pages/Categories`](https://github.com/cs4218/cs4218-2420-ecom-project-team25/blob/main/client/src/pages/Categories.js)

---
Still maintains 100% code coverage in `pages/admin` and `src/hooks` (client)

<img width="1276" alt="image" src="https://github.com/user-attachments/assets/26588e8f-9446-4976-ad45-d16f7607c60e" />
<img width="1277" alt="image" src="https://github.com/user-attachments/assets/dd8490af-e194-4b67-a144-8aba2d33ab81" />
