### PR TITLE
Collect coverage from both backend and frontend

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -59,4 +59,5 @@ jobs:
             -Dsonar.projectKey=econ \
             -Dsonar.sources=. \
             -Dsonar.host.url=http://13.250.126.232 \
-            -Dsonar.token=squ_f7201e61c3e6601e639f92589d7be10d31ba8d89
+            -Dsonar.token=squ_f7201e61c3e6601e639f92589d7be10d31ba8d89 \
+            -Dsonar.javascript.lcov.reportPaths=coverage/**/lcov.info

--- a/jest.backend.config.js
+++ b/jest.backend.config.js
@@ -13,7 +13,14 @@ module.exports = {
 
   // jest code coverage
   collectCoverage: true,
-  collectCoverageFrom: ["controllers/**"],
+  collectCoverageFrom: [
+    "config/**/*.js",
+    "controllers/**/*.js",
+    "helpers/**/*.js",
+    "middlewares/**/*.js",
+    "models/**/*.js",
+  ],
+  coverageDirectory: "coverage/backend",
   coverageThreshold: {
     global: {
       lines: 15,

--- a/jest.frontend.config.js
+++ b/jest.frontend.config.js
@@ -31,7 +31,12 @@ module.exports = {
     "client/src/**/*.{js, jsx}",
     "!client/src/_site/**",
     "!client/src/_markbind/**",
+    "!client/src/index.js",
+    "!client/src/reportWebVitals.js",
+    "!client/src/setupTests.js",
+    "!client/src/App.js",
   ],
+  coverageDirectory: "coverage/frontend",
   coverageThreshold: {
     global: {
       lines: 15,

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,9 @@ sonar.projectVersion=1.0
 
 # Analysis settings
 sonar.sources=client, controllers, helpers, middlewares, models
-sonar.coverage.exclusions=**/__tests__/**, **/*.test.js, **/*.spec.js
+sonar.coverage.exclusions=**/__tests__/**, **/*.test.js, **/*.spec.js, jest.*.config.js, \
+    server.js, index.js, reportWebVitals.js, setupTests.js, App.js, \
+    test-examples/**
 sonar.exclusions=**/__mocks__/**, **/coverage/**, **/coverage/lcov-report/**
 
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,7 +10,8 @@ sonar.projectVersion=1.0
 # Analysis settings
 sonar.sources=client, controllers, helpers, middlewares, models
 sonar.coverage.exclusions=**/__tests__/**, **/*.test.js, **/*.spec.js, jest.*.config.js, \
-    server.js, index.js, reportWebVitals.js, setupTests.js, App.js, \
+    server.js, \
+    client/src/index.js, client/src/reportWebVitals.js, client/src/setupTests.js, client/src/App.js, \
     test-examples/**
 sonar.exclusions=**/__mocks__/**, **/coverage/**, **/coverage/lcov-report/**
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,7 +13,7 @@ sonar.coverage.exclusions=**/__tests__/**, **/*.test.js, **/*.spec.js
 sonar.exclusions=**/__mocks__/**, **/coverage/**, **/coverage/lcov-report/**
 
 
-sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.javascript.lcov.reportPaths=coverage/**/lcov.info
 
 
 sonar.language=js


### PR DESCRIPTION
http://13.250.126.232/code?id=econ&selected=econ%3Acontrollers
Changes:
- Collect coverage from both backend and frontend
- Exclude certain files from coverage on Sonarqube (server.js etc) (reflected with a `-` in the Coverage column)
---

# Before  (see Coverage column):
Code coverage for backend files aren't reflected on sonarqube 
<img width="1195" alt="image" src="https://github.com/user-attachments/assets/d83fca10-7233-428e-a646-86f85e9f5c6e" />

# After:
<img width="1190" alt="image" src="https://github.com/user-attachments/assets/faf73e0f-a2e3-46ec-9d53-b218bf549061" />

