### PR TITLE
Invalidate images requests cache

### DIFF
--- a/client/src/pages/admin/AdminOrders.js
+++ b/client/src/pages/admin/AdminOrders.js
@@ -122,7 +122,9 @@ const AdminOrders = () => {
                     <div className="row mb-2 p-3 card flex-row" key={p._id}>
                       <div className="col-md-4">
                         <img
-                          src={`${API_URLS.GET_PRODUCT_PHOTO}/${p._id}`}
+                          src={`${API_URLS.GET_PRODUCT_PHOTO}/${
+                            p._id
+                          }?id=${Date.now()}`}
                           className="card-img-top"
                           alt={p.name}
                           width="100px"

--- a/client/src/pages/admin/Products.js
+++ b/client/src/pages/admin/Products.js
@@ -6,7 +6,7 @@ import toast from "react-hot-toast";
 import { Link } from "react-router-dom";
 
 export const PRODUCTS_STRINGS = {
-  FETCH_PRODUCTS_ERROR: "Someething went wrong while fetching products",
+  FETCH_PRODUCTS_ERROR: "Something went wrong while fetching products",
 };
 
 export const API_URLS = {
@@ -53,7 +53,7 @@ const Products = () => {
               >
                 <div className="card m-2" style={{ width: "18rem" }}>
                   <img
-                    src={`${API_URLS.GET_PHOTO}/${p._id}`}
+                    src={`${API_URLS.GET_PHOTO}/${p._id}?id=${Date.now()}`}
                     className="card-img-top"
                     alt={p.name}
                   />

--- a/client/src/pages/admin/UpdateProduct.js
+++ b/client/src/pages/admin/UpdateProduct.js
@@ -162,7 +162,10 @@ const UpdateProduct = () => {
                 ))}
               </Select>
               <div className="mb-3">
-                <label className="btn btn-outline-secondary col-md-12">
+                <label
+                  className="btn btn-outline-secondary col-md-12"
+                  htmlFor="upload-photo"
+                >
                   {photo
                     ? photo.name
                     : UPDATE_PRODUCT_STRINGS.UPLOAD_PHOTO_ACTION}
@@ -173,6 +176,7 @@ const UpdateProduct = () => {
                   accept="image/*"
                   onChange={(e) => setPhoto(e.target.files[0])}
                   aria-label={UPDATE_PRODUCT_STRINGS.UPLOAD_PHOTO_ACTION}
+                  id="upload-photo"
                   hidden
                 />
               </div>
@@ -189,7 +193,9 @@ const UpdateProduct = () => {
                 ) : (
                   <div className="text-center">
                     <img
-                      src={`${API_URLS.GET_PRODUCT_PHOTO}/${id}`}
+                      src={`${
+                        API_URLS.GET_PRODUCT_PHOTO
+                      }/${id}?id=${Date.now()}`}
                       alt={UPDATE_PRODUCT_STRINGS.PHOTO_PLACEHODER}
                       height={"200px"}
                       className="img img-responsive"

--- a/client/src/pages/admin/UpdateProduct.test.js
+++ b/client/src/pages/admin/UpdateProduct.test.js
@@ -151,7 +151,9 @@ describe("UpdateProduct", () => {
       })
     ).toHaveAttribute(
       "src",
-      `${API_URLS.GET_PRODUCT_PHOTO}/${mockProduct._id}`
+      expect.stringMatching(
+        new RegExp(`${API_URLS.GET_PRODUCT_PHOTO}/${mockProduct._id}.*`)
+      )
     );
     expect(axios.get).toHaveBeenCalledWith(
       `${API_URLS.GET_PRODUCT}/${mockParams.slug}`


### PR DESCRIPTION
Include an optional query with the current timestamp to ensure that the images requests are not cached. 