### PR TITLE
ci: Fix SonarQube Scans

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -48,16 +48,16 @@ jobs:
           distribution: "temurin"
           java-version: "17"
 
-      # - name: Install SonarQube Scanner
-      #   run: npm install -g sonarqube-scanner
+      - name: Install SonarQube Scanner
+        run: npm install -g sonarqube-scanner
 
-      # - name: Run SonarQube Analysis
-      #   env:
-      #     SONAR_TOKEN: squ_f7201e61c3e6601e639f92589d7be10d31ba8d89
-      #   run: |
-      #     sonar-scanner \
-      #       -Dsonar.projectKey=econ \
-      #       -Dsonar.sources=. \
-      #       -Dsonar.host.url=http://13.250.126.232 \
-      #       -Dsonar.token=squ_f7201e61c3e6601e639f92589d7be10d31ba8d89 \
-      #       -Dsonar.javascript.lcov.reportPaths=coverage/**/lcov.info
+      - name: Run SonarQube Analysis
+        env:
+          SONAR_TOKEN: sqa_0f5269ea22e3abcb15bca74502059fc3e65d3203
+        run: |
+          sonar-scanner \
+            -Dsonar.projectKey=econ \
+            -Dsonar.sources=. \
+            -Dsonar.host.url=http://132.226.117.124 \
+            -Dsonar.token=sqa_0f5269ea22e3abcb15bca74502059fc3e65d3203 \
+            -Dsonar.javascript.lcov.reportPaths=coverage/**/lcov.info

--- a/01-SonarQube.yaml
+++ b/01-SonarQube.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sonarqube
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sonarqube
+  template:
+    metadata:
+      labels:
+        app: sonarqube
+    spec:
+      containers:
+      - name: sonarqube
+        image: sonarqube
+        ports:
+        - containerPort: 9000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sonarqube
+spec:
+  type: LoadBalancer
+  selector:
+    app: sonarqube
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 9000


### PR DESCRIPTION
I deployed SonarQube on an OKE Kubernetes Cluster and exposed it via a Load Balancer on `http://132.226.117.124`.

The same credentials used previously for AWS should work the same.