### PR TITLE
Fix logging out when loading

### DIFF
--- a/client/src/components/RedirectSpinner.js
+++ b/client/src/components/RedirectSpinner.js
@@ -23,7 +23,7 @@ const RedirectSpinner = ({ path = "login" }) => {
         data-testid="redirect-spinner"
         style={{ height: "100vh" }}
       >
-        <h1 className="Text-center">redirecting to you in {count} second </h1>
+        <h1 className="Text-center">redirecting you in {count} second </h1>
         <div className="spinner-border" role="status">
           <span className="visually-hidden">Loading...</span>
         </div>

--- a/client/src/components/RedirectSpinner.js
+++ b/client/src/components/RedirectSpinner.js
@@ -1,0 +1,35 @@
+import React, { useState, useEffect } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+
+const RedirectSpinner = ({ path = "login" }) => {
+  const [count, setCount] = useState(3);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCount((prevValue) => --prevValue);
+    }, 1000);
+    count === 0 &&
+      navigate(`/${path}`, {
+        state: location.pathname,
+      });
+    return () => clearInterval(interval);
+  }, [count, navigate, location, path]);
+  return (
+    <>
+      <div
+        className="d-flex flex-column justify-content-center align-items-center"
+        data-testid="redirect-spinner"
+        style={{ height: "100vh" }}
+      >
+        <h1 className="Text-center">redirecting to you in {count} second </h1>
+        <div className="spinner-border" role="status">
+          <span className="visually-hidden">Loading...</span>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default RedirectSpinner;

--- a/client/src/components/RedirectSpinner.test.js
+++ b/client/src/components/RedirectSpinner.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen, act } from "@testing-library/react";
 import { MemoryRouter, useNavigate, useLocation } from "react-router-dom";
-import Spinner from "./Spinner";
+import RedirectSpinner from "./RedirectSpinner";
 import "@testing-library/jest-dom";
 
 // Mocking the useNavigate and useLocation hooks from react-router-dom
@@ -25,7 +25,7 @@ describe("Spinner Component", () => {
   it("should render countdown and spinner", () => {
     render(
       <MemoryRouter>
-        <Spinner />
+        <RedirectSpinner />
       </MemoryRouter>
     );
 
@@ -40,7 +40,7 @@ describe("Spinner Component", () => {
 
     render(
       <MemoryRouter>
-        <Spinner />
+        <RedirectSpinner />
       </MemoryRouter>
     );
 
@@ -80,7 +80,7 @@ describe("Spinner Component", () => {
 
     render(
       <MemoryRouter>
-        <Spinner />
+        <RedirectSpinner />
       </MemoryRouter>
     );
 
@@ -100,7 +100,7 @@ describe("Spinner Component", () => {
 
     render(
       <MemoryRouter>
-        <Spinner path="register" />
+        <RedirectSpinner path="register" />
       </MemoryRouter>
     );
 

--- a/client/src/components/RedirectSpinner.test.js
+++ b/client/src/components/RedirectSpinner.test.js
@@ -29,7 +29,7 @@ describe("Spinner Component", () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByText(/redirecting to you in/i)).toBeInTheDocument();
+    expect(screen.getByText(/redirecting you in/i)).toBeInTheDocument();
     expect(screen.getByText(/3/)).toBeInTheDocument();
     expect(screen.getByText(/second/i)).toBeInTheDocument();
     expect(screen.getByRole("status")).toBeInTheDocument();
@@ -50,7 +50,7 @@ describe("Spinner Component", () => {
     });
 
     // After 1 second, count should be 2
-    expect(screen.getByText(/redirecting to you in/i)).toBeInTheDocument();
+    expect(screen.getByText(/redirecting you in/i)).toBeInTheDocument();
     expect(screen.getByText(/2/)).toBeInTheDocument();
     expect(screen.getByText(/second/i)).toBeInTheDocument();
 
@@ -60,7 +60,7 @@ describe("Spinner Component", () => {
     });
 
     // After 2 seconds, count should be 1
-    expect(screen.getByText(/redirecting to you in/i)).toBeInTheDocument();
+    expect(screen.getByText(/redirecting you in/i)).toBeInTheDocument();
     expect(screen.getByText(/1/)).toBeInTheDocument();
     expect(screen.getByText(/second/i)).toBeInTheDocument();
 
@@ -70,7 +70,7 @@ describe("Spinner Component", () => {
     });
 
     // After 3 seconds, count should be 0
-    expect(screen.getByText(/redirecting to you in/i)).toBeInTheDocument();
+    expect(screen.getByText(/redirecting you in/i)).toBeInTheDocument();
     expect(screen.getByText(/0/)).toBeInTheDocument();
     expect(screen.getByText(/second/i)).toBeInTheDocument();
   });

--- a/client/src/components/Routes/AdminRoute.js
+++ b/client/src/components/Routes/AdminRoute.js
@@ -1,47 +1,57 @@
-import React from 'react';
-import { useState, useEffect } from 'react';
-import { useAuth } from '../../context/auth';
-import { Outlet } from 'react-router-dom';
-import axios from 'axios';
-import Spinner from '../Spinner';
+import React from "react";
+import { useState, useEffect } from "react";
+import { useAuth } from "../../context/auth";
+import { Outlet } from "react-router-dom";
+import axios from "axios";
+import Spinner from "../Spinner";
+import RedirectSpinner from "../RedirectSpinner";
 
 export const API_URLS = {
   CHECK_ADMIN_AUTH: "/api/v1/auth/admin-auth",
 };
 
 export default function AdminRoute() {
+  const [isLoading, setIsLoading] = useState(false);
   const [ok, setOk] = useState(false);
   const [auth, setAuth] = useAuth();
 
   useEffect(() => {
     const authCheck = async () => {
       try {
+        setIsLoading(true);
         const res = await axios.get(API_URLS.CHECK_ADMIN_AUTH);
+        setIsLoading(false);
+
         if (res.data.ok) {
           setOk(true);
         } else {
           setAuth({
             user: null,
-            token: '',
+            token: "",
           });
-          localStorage.removeItem('auth');
+          localStorage.removeItem("auth");
           setOk(false);
         }
       } catch (err) {
-        console.log(err);
+        localStorage.removeItem("auth");
         setAuth({
           user: null,
-          token: '',
+          token: "",
         });
-        localStorage.removeItem('auth');
         setOk(false);
+        setIsLoading(false);
+        console.log(err);
       }
     };
 
     if (auth?.token) {
       authCheck();
     }
-  }, [auth?.token]);
+  }, [auth?.token, setAuth]);
 
-  return ok ? <Outlet /> : <Spinner />;
+  if (isLoading) {
+    return <Spinner />;
+  }
+
+  return ok ? <Outlet /> : <RedirectSpinner />;
 }

--- a/client/src/components/Routes/AdminRoute.test.js
+++ b/client/src/components/Routes/AdminRoute.test.js
@@ -1,8 +1,5 @@
 import React from 'react';
-import { useState } from 'react';
 import '@testing-library/jest-dom/extend-expect';
-import { Outlet } from 'react-router-dom';
-import Spinner from '../Spinner';
 import axios from 'axios';
 import { useAuth } from '../../context/auth';
 import AdminRoute from './AdminRoute';
@@ -13,18 +10,11 @@ jest.mock('../../context/auth', () => ({
   useAuth: jest.fn(() => [null, jest.fn()]),
 }));
 
-// need to mock react for useEffect
-// https://medium.com/@ashwinKumar0505/how-to-write-unit-test-cases-for-use-effect-react-hooks-using-jest-and-enzyme-5a2a32844a4d
-jest.mock('react', () => ({
-  ...jest.requireActual('react'),
-  useEffect: jest.fn((fn) => fn()),
-  useState: jest.fn(() => [false, jest.fn()]),
-}));
-
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: jest.fn(),
   useLocation: jest.fn(),
+  Outlet: jest.fn(() => <div data-testid="outlet" />),
 }));
 
 let consoleSpy;
@@ -49,58 +39,57 @@ describe('AdminRoute', () => {
     consoleSpy.mockRestore();
   });
 
-  it('should return Spinner by default if no auth token is present', async () => {
+  it('should return RedirectSpinner by default if no auth token is present', async () => {
     useAuth.mockReturnValueOnce([{}, jest.fn()]);
-    expect(AdminRoute()).toStrictEqual(<Spinner />);
 
     render(<AdminRoute />);
 
-    expect(screen.getByTestId('spinner')).toBeInTheDocument();
+    expect(screen.getByTestId('redirect-spinner')).toBeInTheDocument();
     expect(axios.get).not.toHaveBeenCalled();
     expect(consoleSpy).not.toHaveBeenCalled();
-
-    await waitFor(() => {
-      expect(localStorage.removeItem).not.toHaveBeenCalled();
-    });
+    expect(localStorage.removeItem).not.toHaveBeenCalled();
   });
 
-  it('should return Outlet if auth token is present and authCheck returns false', async () => {
+  it('should return RedirectSpinner if auth token is present and authCheck returns false when rendered', async () => {
     useAuth.mockReturnValueOnce([{ token: 'token' }, jest.fn()]);
     axios.get.mockResolvedValueOnce({ data: { ok: false } });
 
-    expect(AdminRoute()).toStrictEqual(<Spinner />);
+    render(<AdminRoute />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('redirect-spinner')).toBeInTheDocument();
+    });
+    expect(axios.get).toHaveBeenCalledWith('/api/v1/auth/admin-auth');
+    expect(localStorage.removeItem).toHaveBeenCalledWith('auth');
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it('should return loading Spinner by default if auth token is present when rendered', async () => {
+    useAuth.mockReturnValueOnce([{ token: 'token' }, jest.fn()]);
+    axios.get.mockResolvedValueOnce({ data: { ok: true } });
 
     render(<AdminRoute />);
 
-    expect(screen.getByTestId('spinner')).toBeInTheDocument();
-
     await waitFor(() => {
-      expect(axios.get).toHaveBeenCalledWith('/api/v1/auth/admin-auth');
+      expect(screen.getByTestId('spinner')).toBeInTheDocument();
     });
-
-    await waitFor(() => {
-      expect(localStorage.removeItem).toHaveBeenCalledWith('auth');
-    });
-
+    expect(axios.get).toHaveBeenCalledWith('/api/v1/auth/admin-auth');
     expect(consoleSpy).not.toHaveBeenCalled();
+    expect(localStorage.removeItem).not.toHaveBeenCalled();
   });
 
   it('should return Outlet if auth token is present and authCheck returns true', async () => {
     useAuth.mockReturnValueOnce([{ token: 'token' }, jest.fn()]);
     axios.get.mockResolvedValueOnce({ data: { ok: true } });
-    useState.mockReturnValueOnce([true, jest.fn()]);
-
-    expect(AdminRoute()).toStrictEqual(<Outlet />);
 
     render(<AdminRoute />);
 
-    expect(screen.getByTestId('spinner')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('outlet')).toBeInTheDocument();
+    });
     expect(axios.get).toHaveBeenCalledWith('/api/v1/auth/admin-auth');
     expect(consoleSpy).not.toHaveBeenCalled();
-
-    await waitFor(() => {
-      expect(localStorage.removeItem).not.toHaveBeenCalled();
-    });
+    expect(localStorage.removeItem).not.toHaveBeenCalled();
   });
 
   it('should not crash if get errors out', async () => {
@@ -111,15 +100,9 @@ describe('AdminRoute', () => {
     render(<AdminRoute />);
 
     await waitFor(() => {
-      expect(axios.get).toHaveBeenCalledWith('/api/v1/auth/admin-auth');
-    });
-
-    await waitFor(() => {
       expect(consoleSpy).toHaveBeenCalledWith(err);
     });
-
-    await waitFor(() => {
-      expect(localStorage.removeItem).toHaveBeenCalledWith('auth');
-    });
+    expect(axios.get).toHaveBeenCalledWith('/api/v1/auth/admin-auth');
+    expect(localStorage.removeItem).toHaveBeenCalledWith('auth');
   });
 });

--- a/client/src/components/Routes/Private.js
+++ b/client/src/components/Routes/Private.js
@@ -1,40 +1,50 @@
-import React from 'react';
-import { useState, useEffect } from 'react';
-import { useAuth } from '../../context/auth';
-import { Outlet } from 'react-router-dom';
-import axios from 'axios';
-import Spinner from '../Spinner';
+import React from "react";
+import { useState, useEffect } from "react";
+import { useAuth } from "../../context/auth";
+import { Outlet } from "react-router-dom";
+import axios from "axios";
+import Spinner from "../Spinner";
+import RedirectSpinner from "../RedirectSpinner";
 
 export default function PrivateRoute() {
+  const [isLoading, setIsLoading] = useState(false);
   const [ok, setOk] = useState(false);
   const [auth, setAuth] = useAuth();
 
   useEffect(() => {
     const authCheck = async () => {
       try {
-        const res = await axios.get('/api/v1/auth/user-auth');
+        setIsLoading(true);
+        const res = await axios.get("/api/v1/auth/user-auth");
+        setIsLoading(false);
+
         if (res.data.ok) {
           setOk(true);
         } else {
           setAuth({
             user: null,
-            token: '',
+            token: "",
           });
-          localStorage.removeItem('auth');
+          localStorage.removeItem("auth");
           setOk(false);
         }
       } catch (err) {
-        console.log(err);
+        localStorage.removeItem("auth");
         setAuth({
           user: null,
-          token: '',
+          token: "",
         });
-        localStorage.removeItem('auth');
         setOk(false);
+        setIsLoading(false);
+        console.log(err);
       }
     };
     if (auth?.token) authCheck();
-  }, [auth?.token]);
+  }, [auth?.token, setAuth]);
 
-  return ok ? <Outlet /> : <Spinner />;
+  if (isLoading) {
+    return <Spinner />;
+  }
+
+  return ok ? <Outlet /> : <RedirectSpinner />;
 }

--- a/client/src/components/Routes/Private.test.js
+++ b/client/src/components/Routes/Private.test.js
@@ -1,35 +1,25 @@
 import React from 'react';
-import { useState } from 'react';
-import { Outlet } from 'react-router-dom';
-import Spinner from '../Spinner';
+import '@testing-library/jest-dom/extend-expect';
 import axios from 'axios';
 import { useAuth } from '../../context/auth';
 import PrivateRoute from './Private';
-import { render, screen, waitFor } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import { render, waitFor, screen } from '@testing-library/react';
 
 jest.mock('axios');
 jest.mock('../../context/auth', () => ({
   useAuth: jest.fn(() => [null, jest.fn()]),
 }));
 
-// need to mock react for useEffect
-// https://medium.com/@ashwinKumar0505/how-to-write-unit-test-cases-for-use-effect-react-hooks-using-jest-and-enzyme-5a2a32844a4d
-jest.mock('react', () => ({
-  ...jest.requireActual('react'),
-  useEffect: jest.fn((fn) => fn()),
-  useState: jest.fn(() => [false, jest.fn()]),
-}));
-
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: jest.fn(),
   useLocation: jest.fn(),
+  Outlet: jest.fn(() => <div data-testid="outlet" />),
 }));
 
 let consoleSpy;
 
-describe('Private', () => {
+describe('PrivateRoute', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
@@ -49,76 +39,70 @@ describe('Private', () => {
     consoleSpy.mockRestore();
   });
 
-  it('should return Spinner by default if no auth token is present', async () => {
+  it('should return RedirectSpinner by default if no auth token is present', async () => {
     useAuth.mockReturnValueOnce([{}, jest.fn()]);
-    expect(PrivateRoute()).toStrictEqual(<Spinner />);
 
     render(<PrivateRoute />);
 
-    expect(screen.getByTestId('spinner')).toBeInTheDocument();
+    expect(screen.getByTestId('redirect-spinner')).toBeInTheDocument();
     expect(axios.get).not.toHaveBeenCalled();
     expect(consoleSpy).not.toHaveBeenCalled();
-
-    await waitFor(() => {
-      expect(localStorage.removeItem).not.toHaveBeenCalled();
-    });
+    expect(localStorage.removeItem).not.toHaveBeenCalled();
   });
 
-  it('should return Spinner if auth token is present and authCheck returns false', async () => {
+  it('should return RedirectSpinner if auth token is present and authCheck returns false when rendered', async () => {
     useAuth.mockReturnValueOnce([{ token: 'token' }, jest.fn()]);
     axios.get.mockResolvedValueOnce({ data: { ok: false } });
 
-    expect(PrivateRoute()).toStrictEqual(<Spinner />);
+    render(<PrivateRoute />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('redirect-spinner')).toBeInTheDocument();
+    });
+    expect(axios.get).toHaveBeenCalledWith('/api/v1/auth/user-auth');
+    expect(localStorage.removeItem).toHaveBeenCalledWith('auth');
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it('should return loading Spinner by default if auth token is present when rendered', async () => {
+    useAuth.mockReturnValueOnce([{ token: 'token' }, jest.fn()]);
+    axios.get.mockResolvedValueOnce({ data: { ok: true } });
 
     render(<PrivateRoute />);
 
-    expect(screen.getByTestId('spinner')).toBeInTheDocument();
-
     await waitFor(() => {
-      expect(axios.get).toHaveBeenCalledWith('/api/v1/auth/user-auth');
+      expect(screen.getByTestId('spinner')).toBeInTheDocument();
     });
-
-    await waitFor(() => {
-      expect(localStorage.removeItem).toHaveBeenCalledWith('auth');
-    });
-
+    expect(axios.get).toHaveBeenCalledWith('/api/v1/auth/user-auth');
     expect(consoleSpy).not.toHaveBeenCalled();
+    expect(localStorage.removeItem).not.toHaveBeenCalled();
   });
 
   it('should return Outlet if auth token is present and authCheck returns true', async () => {
     useAuth.mockReturnValueOnce([{ token: 'token' }, jest.fn()]);
     axios.get.mockResolvedValueOnce({ data: { ok: true } });
-    useState.mockReturnValueOnce([true, jest.fn()]);
-
-    expect(PrivateRoute()).toStrictEqual(<Outlet />);
 
     render(<PrivateRoute />);
 
-    expect(screen.getByTestId('spinner')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('outlet')).toBeInTheDocument();
+    });
     expect(axios.get).toHaveBeenCalledWith('/api/v1/auth/user-auth');
     expect(consoleSpy).not.toHaveBeenCalled();
-
-    await waitFor(() => {
-      expect(localStorage.removeItem).not.toHaveBeenCalled();
-    });
+    expect(localStorage.removeItem).not.toHaveBeenCalled();
   });
 
   it('should not crash if get errors out', async () => {
     const err = new Error('Failed to query auth status');
     axios.get.mockRejectedValueOnce(err);
     useAuth.mockReturnValueOnce([{ token: 'token' }, jest.fn()]);
-    render(<PrivateRoute />);
 
-    await waitFor(() => {
-      expect(axios.get).toHaveBeenCalledWith('/api/v1/auth/user-auth');
-    });
+    render(<PrivateRoute />);
 
     await waitFor(() => {
       expect(consoleSpy).toHaveBeenCalledWith(err);
     });
-
-    await waitFor(() => {
-      expect(localStorage.removeItem).toHaveBeenCalledWith('auth');
-    });
+    expect(axios.get).toHaveBeenCalledWith('/api/v1/auth/user-auth');
+    expect(localStorage.removeItem).toHaveBeenCalledWith('auth');
   });
 });

--- a/client/src/components/Spinner.js
+++ b/client/src/components/Spinner.js
@@ -1,19 +1,6 @@
-import React, { useState, useEffect } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
-const Spinner = ({ path = "login" }) => {
-  const [count, setCount] = useState(3);
-  const navigate = useNavigate();
-  const location = useLocation();
+import React from "react";
 
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setCount((prevValue) => --prevValue);
-    }, 1000);
-    count === 0 && navigate(`/${path}`, {
-        state: location.pathname,
-      });
-    return () => clearInterval(interval);
-  }, [count, navigate, location]);
+const Spinner = () => {
   return (
     <>
       <div
@@ -21,7 +8,6 @@ const Spinner = ({ path = "login" }) => {
         data-testid="spinner"
         style={{ height: "100vh" }}
       >
-        <h1 className="Text-center">redirecting to you in {count} second </h1>
         <div className="spinner-border" role="status">
           <span className="visually-hidden">Loading...</span>
         </div>

--- a/client/src/integration-tests/pages/admin/AdminOrders.integration.test.jsx
+++ b/client/src/integration-tests/pages/admin/AdminOrders.integration.test.jsx
@@ -302,12 +302,12 @@ describe("AdminOrders Integration Tests", () => {
     setup();
 
     await waitFor(() => {
-      expect(axios.get).toHaveBeenCalledWith(
-        ADMIN_ROUTE_API_URLS.CHECK_ADMIN_AUTH
-      );
+      expect(
+        screen.getByRole("heading", { name: /redirecting to you in/i })
+      ).toBeInTheDocument();
     });
-    expect(
-      screen.getByRole("heading", { name: /redirecting to you in/i })
-    ).toBeInTheDocument();
+    expect(axios.get).toHaveBeenCalledWith(
+      ADMIN_ROUTE_API_URLS.CHECK_ADMIN_AUTH
+    );
   });
 });

--- a/client/src/integration-tests/pages/admin/AdminOrders.integration.test.jsx
+++ b/client/src/integration-tests/pages/admin/AdminOrders.integration.test.jsx
@@ -290,7 +290,7 @@ describe("AdminOrders Integration Tests", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("heading", { name: /redirecting to you in/i })
+        screen.getByRole("heading", { name: /redirecting you in/i })
       ).toBeInTheDocument();
     });
   });
@@ -303,7 +303,7 @@ describe("AdminOrders Integration Tests", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("heading", { name: /redirecting to you in/i })
+        screen.getByRole("heading", { name: /redirecting you in/i })
       ).toBeInTheDocument();
     });
     expect(axios.get).toHaveBeenCalledWith(

--- a/client/src/integration-tests/pages/admin/CreateCategory.integration.test.jsx
+++ b/client/src/integration-tests/pages/admin/CreateCategory.integration.test.jsx
@@ -308,7 +308,7 @@ describe("CreateCategory Integration Tests", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("heading", { name: /redirecting to you in/i })
+        screen.getByRole("heading", { name: /redirecting you in/i })
       ).toBeInTheDocument();
     });
   });
@@ -330,7 +330,7 @@ describe("CreateCategory Integration Tests", () => {
       );
     });
     expect(
-      screen.getByRole("heading", { name: /redirecting to you in/i })
+      screen.getByRole("heading", { name: /redirecting you in/i })
     ).toBeInTheDocument();
   });
 });

--- a/client/src/integration-tests/pages/admin/CreateProduct.integration.test.jsx
+++ b/client/src/integration-tests/pages/admin/CreateProduct.integration.test.jsx
@@ -353,7 +353,7 @@ describe("CreateProduct Integration Tests", () => {
     await waitFor(() => {
       expect(
         screen.getByRole("heading", {
-          name: getCaseInsensitiveRegex("redirecting to you in"),
+          name: getCaseInsensitiveRegex("redirecting you in"),
         })
       ).toBeInTheDocument();
     });
@@ -373,7 +373,7 @@ describe("CreateProduct Integration Tests", () => {
       );
     });
     expect(
-      screen.getByRole("heading", { name: /redirecting to you in/i })
+      screen.getByRole("heading", { name: /redirecting you in/i })
     ).toBeInTheDocument();
   });
 });

--- a/client/src/integration-tests/pages/admin/UpdateProduct.integration.test.jsx
+++ b/client/src/integration-tests/pages/admin/UpdateProduct.integration.test.jsx
@@ -465,7 +465,7 @@ describe("UpdateProduct Integration Tests", () => {
       );
     });
     expect(
-      screen.getByRole("heading", { name: /redirecting to you in/i })
+      screen.getByRole("heading", { name: /redirecting you in/i })
     ).toBeInTheDocument();
   });
 });

--- a/client/src/integration-tests/pages/admin/Users.integration.test.jsx
+++ b/client/src/integration-tests/pages/admin/Users.integration.test.jsx
@@ -210,12 +210,12 @@ describe("Users Integration Tests", () => {
     setup();
 
     await waitFor(() => {
-      expect(axios.get).toHaveBeenCalledWith(
-        ADMIN_ROUTE_API_URLS.CHECK_ADMIN_AUTH
-      );
+      expect(
+        screen.getByRole("heading", { name: /redirecting to you in/i })
+      ).toBeInTheDocument();
     });
-    expect(
-      screen.getByRole("heading", { name: /redirecting to you in/i })
-    ).toBeInTheDocument();
+    expect(axios.get).toHaveBeenCalledWith(
+      ADMIN_ROUTE_API_URLS.CHECK_ADMIN_AUTH
+    );
   });
 });

--- a/client/src/integration-tests/pages/admin/Users.integration.test.jsx
+++ b/client/src/integration-tests/pages/admin/Users.integration.test.jsx
@@ -198,7 +198,7 @@ describe("Users Integration Tests", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("heading", { name: /redirecting to you in/i })
+        screen.getByRole("heading", { name: /redirecting you in/i })
       ).toBeInTheDocument();
     });
   });
@@ -211,7 +211,7 @@ describe("Users Integration Tests", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("heading", { name: /redirecting to you in/i })
+        screen.getByRole("heading", { name: /redirecting you in/i })
       ).toBeInTheDocument();
     });
     expect(axios.get).toHaveBeenCalledWith(

--- a/client/src/integration-tests/pages/user/Orders.integration.test.jsx
+++ b/client/src/integration-tests/pages/user/Orders.integration.test.jsx
@@ -168,7 +168,7 @@ describe("Orders Integration Tests", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("heading", { name: /redirecting to you in/i })
+        screen.getByRole("heading", { name: /redirecting you in/i })
       ).toBeInTheDocument();
     });
   });

--- a/client/src/integration-tests/pages/user/Profile.integration.test.jsx
+++ b/client/src/integration-tests/pages/user/Profile.integration.test.jsx
@@ -274,7 +274,7 @@ describe("Profile Integration Tests", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("heading", { name: /redirecting to you in/i })
+        screen.getByRole("heading", { name: /redirecting you in/i })
       ).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
If checkAuth endpoint takes longer than 3 seconds to respond, the user will automatically be logged out.

Fixed by adding a loading state when checking for auth in `PrivateRoute` and `AdminRoute`. 
If loading, it will use a normal spinner with no redirection.